### PR TITLE
refactor - 폴더구조 재정의 및 UI/UX 개선

### DIFF
--- a/frontend/app/src/main/java/com/apptive/japkor/ui/components/CustomTextField.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/components/CustomTextField.kt
@@ -1,0 +1,39 @@
+package com.apptive.japkor.ui.components
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.apptive.japkor.ui.theme.CustomColor
+
+@Composable
+fun CustomOutlinedTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(50.dp)
+            .border(
+                width = 1.dp,
+                color = CustomColor.gray100,
+                shape = RoundedCornerShape(10.dp)
+            ),
+        shape = RoundedCornerShape(10.dp),
+        placeholder = {
+            CustomText(
+                text = placeholder,
+                type = CustomTextType.bodyMedium,
+                color = CustomColor.gray300
+            )
+        }
+    )
+}

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
@@ -30,10 +30,6 @@ import com.apptive.japkor.R
 import com.apptive.japkor.ui.components.CustomText
 import com.apptive.japkor.ui.components.CustomTextType
 import com.apptive.japkor.ui.components.StepIndicator
-import com.apptive.japkor.ui.components.requiredinfo.Step1Content
-import com.apptive.japkor.ui.components.requiredinfo.Step2Content
-import com.apptive.japkor.ui.components.requiredinfo.Step3Content
-import com.apptive.japkor.ui.components.requiredinfo.Step4Content
 import com.apptive.japkor.ui.theme.CustomColor
 
 @Composable

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -79,6 +80,7 @@ fun RequiredInfoScreen(
         }
 
         // 하단 버튼
+        Spacer(modifier = Modifier.weight(1f)) // Pushes the buttons to the bottom
         if (currentStep.value == 1) {
             // Step 1: 다음 버튼만
             Button(
@@ -92,7 +94,7 @@ fun RequiredInfoScreen(
                 colors = ButtonDefaults.buttonColors(
                     containerColor = CustomColor.gray300
                 ),
-                shape = RoundedCornerShape(10.dp)
+                shape = RoundedCornerShape(16.dp)
             ) {
                 CustomText(
                     text = "다음",
@@ -119,7 +121,7 @@ fun RequiredInfoScreen(
                     colors = ButtonDefaults.buttonColors(
                         containerColor = CustomColor.gray100
                     ),
-                    shape = RoundedCornerShape(10.dp)
+                    shape = RoundedCornerShape(16.dp)
                 ) {
                     CustomText(
                         text = "이전",
@@ -144,7 +146,7 @@ fun RequiredInfoScreen(
                     colors = ButtonDefaults.buttonColors(
                         containerColor = CustomColor.gray300
                     ),
-                    shape = RoundedCornerShape(10.dp)
+                    shape = RoundedCornerShape(16.dp)
                 ) {
                     CustomText(
                         text = if (currentStep.value < 4) "다음" else "완료",
@@ -154,6 +156,8 @@ fun RequiredInfoScreen(
                 }
             }
         }
+
+        Spacer(modifier = Modifier.navigationBarsPadding())
 
     }
 }

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
@@ -31,6 +31,11 @@ import com.apptive.japkor.R
 import com.apptive.japkor.ui.components.CustomText
 import com.apptive.japkor.ui.components.CustomTextType
 import com.apptive.japkor.ui.components.StepIndicator
+import com.apptive.japkor.ui.requiredinfo.steps.Step1Content
+import com.apptive.japkor.ui.requiredinfo.steps.Step2Content
+import com.apptive.japkor.ui.requiredinfo.steps.Step3Content
+import com.apptive.japkor.ui.requiredinfo.steps.Step4Content
+import com.apptive.japkor.ui.requiredinfo.steps.Step5Content
 import com.apptive.japkor.ui.theme.CustomColor
 
 @Composable

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
@@ -68,7 +68,7 @@ fun RequiredInfoScreen(
         }
 
         // 스텝 인디케이터 (4단계, 높이 3dp)
-        StepIndicator(currentStep = currentStep.value)
+        StepIndicator(currentStep = currentStep.value, totalSteps = 5)
         Spacer(modifier = Modifier.height(24.dp))
 
         // Step에 따른 Body UI
@@ -77,6 +77,7 @@ fun RequiredInfoScreen(
             2 -> Step2Content()
             3 -> Step3Content()
             4 -> Step4Content()
+            5 -> Step5Content()
         }
 
         // 하단 버튼
@@ -133,7 +134,7 @@ fun RequiredInfoScreen(
                 // 다음/완료 버튼
                 Button(
                     onClick = {
-                        if (currentStep.value < 4) {
+                        if (currentStep.value < 5) {
                             currentStep.value += 1
                         } else {
                             // 마지막 단계에서 완료 처리

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step1Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step1Content.kt
@@ -1,4 +1,4 @@
-package com.apptive.japkor.ui.components.requiredinfo
+package com.apptive.japkor.ui.requiredinfo
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step2Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step2Content.kt
@@ -78,6 +78,5 @@ fun Step2Content() {
             type = CustomTextType.bodyLarge,
         )
 
-        Spacer(modifier = Modifier.height(50.dp))
     }
 }

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step2Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step2Content.kt
@@ -7,8 +7,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -27,7 +30,9 @@ fun Step2Content() {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 50.dp),
+            .padding(horizontal = 50.dp)
+            .verticalScroll(rememberScrollState())
+            .imePadding(),
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step2Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step2Content.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.apptive.japkor.ui.components.CustomOutlinedTextField
@@ -69,7 +68,7 @@ fun Step2Content() {
                     onValueChange = {},
                     placeholder = placeholder
                 )
-            }//
+            }
 
         }
 
@@ -82,10 +81,3 @@ fun Step2Content() {
         Spacer(modifier = Modifier.height(50.dp))
     }
 }
-
-@Preview(showBackground = true)
-@Composable
-fun Step2ContentPreview() {
-    Step2Content()
-}
-

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step2Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step2Content.kt
@@ -1,7 +1,6 @@
 package com.apptive.japkor.ui.requiredinfo
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -18,38 +16,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.apptive.japkor.ui.components.CustomOutlinedTextField
 import com.apptive.japkor.ui.components.CustomText
 import com.apptive.japkor.ui.components.CustomTextType
 import com.apptive.japkor.ui.theme.CustomColor
 
-
-@Composable
-fun CustomOutlinedTextField(
-    value: String,
-    onValueChange: (String) -> Unit,
-    placeholder: String
-) {
-    OutlinedTextField(
-        value = value,
-        onValueChange = onValueChange,
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(50.dp)
-            .border(
-                width = 1.dp,
-                color = CustomColor.gray100,
-                shape = RoundedCornerShape(10.dp)
-            ),
-        shape = RoundedCornerShape(10.dp),
-        placeholder = {
-            CustomText(
-                text = placeholder,
-                type = CustomTextType.bodyMedium,
-                color = CustomColor.gray300
-            )
-        }
-    )
-}
 
 @Composable
 fun Step2Content() {

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step2Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step2Content.kt
@@ -1,4 +1,4 @@
-package com.apptive.japkor.ui.components.requiredinfo
+package com.apptive.japkor.ui.requiredinfo
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,7 +29,7 @@ fun CustomOutlinedTextField(
     onValueChange: (String) -> Unit,
     placeholder: String
 ) {
-    androidx.compose.material3.OutlinedTextField(
+    OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
         modifier = Modifier

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step3Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step3Content.kt
@@ -1,4 +1,4 @@
-package com.apptive.japkor.ui.components.requiredinfo
+package com.apptive.japkor.ui.requiredinfo
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step4Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step4Content.kt
@@ -1,4 +1,4 @@
-package com.apptive.japkor.ui.components.requiredinfo
+package com.apptive.japkor.ui.requiredinfo
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step5Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/Step5Content.kt
@@ -1,0 +1,47 @@
+package com.apptive.japkor.ui.requiredinfo
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.apptive.japkor.ui.components.CustomText
+import com.apptive.japkor.ui.components.CustomTextType
+import com.apptive.japkor.ui.theme.CustomColor
+
+@Composable
+fun Step5Content() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 50.dp),
+        horizontalAlignment = Alignment.Start,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        CustomText(
+            text = "나의 성격",
+            type = CustomTextType.mainRegularLarge,
+            size = 16.sp
+        )
+        CustomText(
+            text = "성격, 이상형, 데이트 스타일 등등",
+            color = CustomColor.gray400,
+            type = CustomTextType.mainRegularSmall,
+        )
+        Spacer(modifier = Modifier.height(50.dp))
+
+        // 자기소개 작성 UI 구현 (예시)
+        CustomText(
+            text = "Step 5: 화면",
+            color = CustomColor.gray300,
+            type = CustomTextType.bodyLarge,
+        )
+        Spacer(modifier = Modifier.height(200.dp))
+    }
+}

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step1Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step1Content.kt
@@ -1,4 +1,4 @@
-package com.apptive.japkor.ui.requiredinfo
+package com.apptive.japkor.ui.requiredinfo.steps
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step2Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step2Content.kt
@@ -1,4 +1,4 @@
-package com.apptive.japkor.ui.requiredinfo
+package com.apptive.japkor.ui.requiredinfo.steps
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step3Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step3Content.kt
@@ -1,4 +1,4 @@
-package com.apptive.japkor.ui.requiredinfo
+package com.apptive.japkor.ui.requiredinfo.steps
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step4Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step4Content.kt
@@ -1,4 +1,4 @@
-package com.apptive.japkor.ui.requiredinfo
+package com.apptive.japkor.ui.requiredinfo.steps
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step5Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step5Content.kt
@@ -1,4 +1,4 @@
-package com.apptive.japkor.ui.requiredinfo
+package com.apptive.japkor.ui.requiredinfo.steps
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column


### PR DESCRIPTION
# 작업내용

- steps 페이지 위치 변경 ```ui/requiredinfo/steps/...```
- 공용 텍스트필트 컴포넌트 분리
- 정보입력페이지 하단 버튼 위치 고정
- step2 스크롤 추가(키보드 선택 시 UI 가려짐)
- 정보입력 페이지 5단계로 개선

---

## 추후 해야할 것
- [ ] 정보입력 완료페이지 추가 ```ui/requiredinfo/steps/...``` 아마 요기다? ```ConfirmContent.kt``` 이런식으로 ?
- [ ] 텍스트필드 UI 개선

## 스크린샷 (참고)

<img width=30% alt="스크린샷 2025-10-05 오후 5 16 37" src="https://github.com/user-attachments/assets/fd62f573-f0cc-46b5-bbf5-cb228911bdfb" />


<img width=30% alt="스크린샷 2025-10-05 오후 5 17 01" src="https://github.com/user-attachments/assets/4cefff7c-ff6b-426f-b759-17ae60ea18db" />
