### PR TITLE
feat - step3 화면 구현

### DIFF
--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step2Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step2Content.kt
@@ -78,9 +78,10 @@ fun Step2Content() {
         }
 
         CustomText(
-            text = " 거짓 정보 입력시, 큰일남!!",
+            text = "거짓 정보 입력시, 큰일남!!",
             color = CustomColor.gray300,
             type = CustomTextType.bodyLarge,
+            modifier = Modifier.padding(horizontal = 7.dp)
         )
 
     }

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step3Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step3Content.kt
@@ -67,9 +67,10 @@ fun Step3Content() {
         }
 
         CustomText(
-            text = " '학력' 및 '재산' 정보는 선택 입력 사항입니다.\n 입력시, 더 빠르고 정확한 매칭에 도움을 줄 수 있습니다.",
+            text = "'학력' 및 '재산' 정보는 선택 입력 사항입니다.\n입력시, 더 빠르고 정확한 매칭에 도움을 줄 수 있습니다.",
             color = CustomColor.gray300,
             type = CustomTextType.bodyLarge,
+            modifier = Modifier.padding(horizontal = 7.dp)
         )
     }
 }

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step3Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step3Content.kt
@@ -1,16 +1,20 @@
 package com.apptive.japkor.ui.requiredinfo.steps
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.apptive.japkor.ui.components.CustomOutlinedTextField
 import com.apptive.japkor.ui.components.CustomText
 import com.apptive.japkor.ui.components.CustomTextType
 import com.apptive.japkor.ui.theme.CustomColor
@@ -37,11 +41,35 @@ fun Step3Content() {
         Spacer(modifier = Modifier.height(50.dp))
 
         // 프로필 사진 등록 UI 구현 (예시)
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.White, shape = RoundedCornerShape(16.dp)),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            CustomOutlinedTextField(
+                value = "",
+                onValueChange = {},
+                placeholder = "학력(인증)"
+            )
+            CustomOutlinedTextField(
+                value = "",
+                onValueChange = {},
+                placeholder = "재산(인증)"
+            )
+            CustomOutlinedTextField(
+                value = "",
+                onValueChange = {},
+                placeholder = "기타정보"
+            )
+
+        }
+
         CustomText(
-            text = "Step 3: 화면",
+            text = " '학력' 및 '재산' 정보는 선택 입력 사항입니다.\n 입력시, 더 빠르고 정확한 매칭에 도움을 줄 수 있습니다.",
             color = CustomColor.gray300,
             type = CustomTextType.bodyLarge,
         )
-        Spacer(modifier = Modifier.height(200.dp))
     }
 }


### PR DESCRIPTION
# 변경점 👍
step3 화면 구현 완료했습니다!
 
# 스크린샷 🖼
<img width="313" height="640" alt="image" src="https://github.com/user-attachments/assets/8c94d521-c91c-407a-91ad-ee3a9f97533c" />
 
# 비고 ✏
1. 첨부한 사진은 안드로이드스튜디오 빌드 화면인데, 제 공기계에서는 폰트도 커지고 잘리고 뭔가 구림...

2. 로그인 & step12345 화면에서 한국어 선택 버튼 필요합니다!!

현재:
<img width="297" height="141" alt="image" src="https://github.com/user-attachments/assets/ab110368-cd8a-460c-b568-7a62ea6df0c7" />

피그마:
<img width="288" height="153" alt="image" src="https://github.com/user-attachments/assets/6a792dfa-6ee6-4428-9ac8-0fb6ae5e3a97" />
