### PR TITLE
feat: Step4 "프로필 사진 가이드 보기" 버튼 추가

### DIFF
--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step4Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step4Content.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.apptive.japkor.ui.components.CustomText
@@ -71,6 +72,21 @@ fun Step4Content() {
             color = CustomColor.gray300,
             type = CustomTextType.bodyLarge,
             modifier = Modifier.padding(horizontal = 7.dp)
+        )
+
+        Spacer(modifier = Modifier.height(85.dp))
+        CustomText(
+            text = "프로필 사진 가이드 보기",
+            color = CustomColor.gray300,
+            type = CustomTextType.bodyLarge,
+            underline = true,
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(vertical = 12.dp)
+                .clickable(
+                    role = Role.Button,
+                    onClick = { /* TODO: 사진 가이드 보기 */ }
+                )
         )
     }
 }


### PR DESCRIPTION
# 변경점 👍
 Step4 화면에서 프로필 사진 가이드 보기 버튼을 빼먹어서 추가했습니다

# 스크린샷 🖼
<img width=30% height="585" alt="image" src="https://github.com/user-attachments/assets/6752c12f-e48a-4450-8cce-9240e1733c6b" />
