### PR TITLE
feat - step5 및 심사 완료 페이지 추가

### DIFF
--- a/frontend/app/src/main/java/com/apptive/japkor/navigation/AppNavHost.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/navigation/AppNavHost.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.apptive.japkor.ui.language.LanguageScreen
 import com.apptive.japkor.ui.login.LoginScreen
+import com.apptive.japkor.ui.requiredinfo.RequiredInfoCompleteScreen
 import com.apptive.japkor.ui.requiredinfo.RequiredInfoScreen
 import com.apptive.japkor.ui.signup.SignUpScreen
 
@@ -15,6 +16,8 @@ sealed class Screen(val route: String) {
     object Language : Screen("language")
 
     object RequiredInfo : Screen("requiredinfo")
+
+    object RequiredInfoComplete : Screen("requiredinfo_complete")
 
     object SignUp : Screen("signup")
 }
@@ -33,6 +36,9 @@ fun AppNavHost(navController: NavHostController, isSignedIn: Boolean) {
         }
         composable(Screen.RequiredInfo.route) {
             RequiredInfoScreen(navController)
+        }
+        composable(Screen.RequiredInfoComplete.route) {
+            RequiredInfoCompleteScreen(navController)
         }
         composable(
             route = Screen.SignUp.route,

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/components/CustomText.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/components/CustomText.kt
@@ -37,140 +37,55 @@ val STFangSong = FontFamily(
 )
 
 enum class CustomTextType {
-    displayLarge, displayMedium, displaySmall,
-    headlineLarge, headlineMedium, headlineSmall,
-    titleLarge, titleMedium, titleSmall,
-    bodyLarge, bodyMedium, bodySmall,
-    labelLarge, labelMedium, labelSmall,
-    mainBoldLarge, mainBoldMedium, mainBoldSmall,
-    mainRegularLarge, mainRegularMedium, mainRegularSmall,
+    display,
+    headline,
+    title,
+    body,
+    label,
+    mainBold,
+    mainRegular,
     STFangSong
 }
 
 private fun getTextStyle(type: CustomTextType): TextStyle = when (type) {
-    CustomTextType.displayLarge -> TextStyle(
-        fontSize = 57.sp,
-        fontWeight = FontWeight.W700,
-        fontFamily = Pretendard,
-        letterSpacing = (-0.25).sp
-    )
-
-    CustomTextType.displayMedium -> TextStyle(
+    CustomTextType.display -> TextStyle(
         fontSize = 45.sp,
         fontWeight = FontWeight.W700,
         fontFamily = Pretendard
     )
 
-    CustomTextType.displaySmall -> TextStyle(
-        fontSize = 36.sp,
-        fontWeight = FontWeight.W700,
-        fontFamily = Pretendard
-    )
-
-    CustomTextType.headlineLarge -> TextStyle(
-        fontSize = 32.sp,
-        fontWeight = FontWeight.W700,
-        fontFamily = Pretendard
-    )
-
-    CustomTextType.headlineMedium -> TextStyle(
+    CustomTextType.headline -> TextStyle(
         fontSize = 28.sp,
         fontWeight = FontWeight.W700,
         fontFamily = Pretendard
     )
 
-    CustomTextType.headlineSmall -> TextStyle(
-        fontSize = 24.sp,
-        fontWeight = FontWeight.W700,
-        fontFamily = Pretendard
-    )
-
-    CustomTextType.titleLarge -> TextStyle(
-        fontSize = 22.sp,
-        fontWeight = FontWeight.W600,
-        fontFamily = Pretendard
-    )
-
-    CustomTextType.titleMedium -> TextStyle(
+    CustomTextType.title -> TextStyle(
         fontSize = 16.sp,
         fontWeight = FontWeight.W600,
         fontFamily = Pretendard
     )
 
-    CustomTextType.titleSmall -> TextStyle(
-        fontSize = 14.sp,
-        fontWeight = FontWeight.W600,
-        fontFamily = Pretendard
-    )
-
-    CustomTextType.bodyLarge -> TextStyle(
-        fontSize = 16.sp,
-        fontWeight = FontWeight.W400,
-        fontFamily = Pretendard
-    )
-
-    CustomTextType.bodyMedium -> TextStyle(
+    CustomTextType.body -> TextStyle(
         fontSize = 14.sp,
         fontWeight = FontWeight.W400,
         fontFamily = Pretendard
     )
 
-    CustomTextType.bodySmall -> TextStyle(
-        fontSize = 12.sp,
-        fontWeight = FontWeight.W400,
-        fontFamily = Pretendard
-    )
-
-    CustomTextType.labelLarge -> TextStyle(
-        fontSize = 14.sp,
-        fontWeight = FontWeight.W500,
-        fontFamily = Pretendard
-    )
-
-    CustomTextType.labelMedium -> TextStyle(
+    CustomTextType.label -> TextStyle(
         fontSize = 12.sp,
         fontWeight = FontWeight.W500,
         fontFamily = Pretendard
     )
 
-    CustomTextType.labelSmall -> TextStyle(
-        fontSize = 11.sp,
-        fontWeight = FontWeight.W500,
-        fontFamily = Pretendard
-    )
-
-    CustomTextType.mainBoldLarge -> TextStyle(
-        fontSize = 22.sp,
-        fontWeight = FontWeight.W700,
-        fontFamily = GowunBatnag
-    )
-
-    CustomTextType.mainBoldMedium -> TextStyle(
+    CustomTextType.mainBold -> TextStyle(
         fontSize = 16.sp,
         fontWeight = FontWeight.W700,
         fontFamily = GowunBatnag
     )
 
-    CustomTextType.mainBoldSmall -> TextStyle(
-        fontSize = 14.sp,
-        fontWeight = FontWeight.W700,
-        fontFamily = GowunBatnag
-    )
-
-    CustomTextType.mainRegularLarge -> TextStyle(
-        fontSize = 22.sp,
-        fontWeight = FontWeight.W400,
-        fontFamily = GowunBatnag
-    )
-
-    CustomTextType.mainRegularMedium -> TextStyle(
+    CustomTextType.mainRegular -> TextStyle(
         fontSize = 16.sp,
-        fontWeight = FontWeight.W400,
-        fontFamily = GowunBatnag
-    )
-
-    CustomTextType.mainRegularSmall -> TextStyle(
-        fontSize = 14.sp,
         fontWeight = FontWeight.W400,
         fontFamily = GowunBatnag
     )
@@ -186,7 +101,7 @@ private fun getTextStyle(type: CustomTextType): TextStyle = when (type) {
 fun CustomText(
     text: String,
     modifier: Modifier = Modifier,
-    type: CustomTextType = CustomTextType.bodyMedium,
+    type: CustomTextType = CustomTextType.body,
     style: TextStyle? = null,
     color: Color = Color.Unspecified,
     textAlign: TextAlign? = null,

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/components/CustomTextField.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/components/CustomTextField.kt
@@ -36,7 +36,7 @@ fun CustomOutlinedTextField(
         placeholder = {
             CustomText(
                 text = placeholder,
-                type = CustomTextType.bodyMedium,
+                type = CustomTextType.body,
                 color = CustomColor.gray300
             )
         },

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/components/step4/PhotoUploadButton.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/components/step4/PhotoUploadButton.kt
@@ -1,0 +1,52 @@
+package com.apptive.japkor.ui.components.step4
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun PhotoUploadButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {}
+) {
+    val shape = RoundedCornerShape(10.dp)
+
+    // 바탕 카드 (soft shadow)
+    Box(
+        modifier = modifier
+            .shadow(2.dp, shape, clip = false)
+            .clip(shape)
+            .background(Color.White)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        // 가운데 옅은 원 + '+' 아이콘
+        Box(
+            modifier = Modifier
+                .size(25.dp)                          // 원 크기
+                .background(
+                    color = Color(0xFFF5F6F8),        // 연한 회색 배경
+                    shape = CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "+",
+                fontSize = 22.sp,
+                color = Color(0xFFB8BDC7)            // 아이콘 컬러
+            )
+        }
+    }
+}

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/components/step4/PhotoUploadGrid.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/components/step4/PhotoUploadGrid.kt
@@ -1,0 +1,35 @@
+package com.apptive.japkor.ui.components.step4
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PhotoUploadGrid() {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        val cells = (0 until 6).toList()
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            cells.chunked(3).forEach { row ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    row.forEach { idx ->
+                        PhotoUploadButton(
+                            modifier = Modifier
+                                .weight(1f)
+                                .aspectRatio(1f),   // 정사각형
+                            onClick = { /* TODO: photo pick for idx */ }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/language/LanguageScreen.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/language/LanguageScreen.kt
@@ -66,7 +66,7 @@ fun LanguageScreen(navController: NavController) {
         Column(modifier = Modifier.padding(horizontal = 10.dp)) {
             CustomText(
                 text = "en",
-                type = CustomTextType.mainRegularLarge,
+                type = CustomTextType.mainRegular,
                 color = CustomColor.white,
                 size = 35.sp
             )
@@ -75,7 +75,7 @@ fun LanguageScreen(navController: NavController) {
             CustomText(
                 text = "당신의 인연을 잇는 소개팅 어플 ‘앤’ 입니다\n" +
                         "언어를 선택하여 시작해주세요",
-                type = CustomTextType.mainRegularSmall,
+                type = CustomTextType.mainRegular,
                 color = CustomColor.white,
                 size = 16.sp
             )
@@ -107,7 +107,7 @@ fun LanguageScreen(navController: NavController) {
             Spacer(modifier = Modifier.height(16.dp))
             CustomText(
                 text = "인연",
-                type = CustomTextType.mainRegularLarge,
+                type = CustomTextType.mainRegular,
                 color = CustomColor.white,
                 modifier = Modifier
                     .fillMaxWidth()

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/login/LoginScreen.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/login/LoginScreen.kt
@@ -108,7 +108,7 @@ fun LoginScreen(navController: NavController) {
                 ) {
                     CustomText(
                         text = "한국어",
-                        type = CustomTextType.bodyLarge,
+                        type = CustomTextType.body,
                         color = CustomColor.gray300,
                         underline = true
                     )
@@ -126,13 +126,13 @@ fun LoginScreen(navController: NavController) {
             ) {
                 CustomText(
                     text = "어서오세요\nen 입니다",
-                    type = CustomTextType.mainRegularLarge,
+                    type = CustomTextType.mainRegular,
                     size = 32.sp
                 )
                 CustomText(
                     text = "당신의 인연을 잇는 소개팅 어플 '앤' 입니다\n",
                     color = CustomColor.gray400,
-                    type = CustomTextType.mainRegularSmall,
+                    type = CustomTextType.mainRegular,
                 )
 
                 Column(
@@ -229,7 +229,7 @@ fun LoginScreen(navController: NavController) {
                     ) {
                         CustomText(
                             text = "로그인",
-                            type = CustomTextType.bodyLarge,
+                            type = CustomTextType.body,
                             color = Color.Black
                         )
                     }
@@ -243,31 +243,31 @@ fun LoginScreen(navController: NavController) {
                     ) {
                         CustomText(
                             text = "아이디 찾기",
-                            type = CustomTextType.bodyMedium,
+                            type = CustomTextType.body,
                             color = CustomColor.black,
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         CustomText(
                             text = " | ",
-                            type = CustomTextType.bodyMedium,
+                            type = CustomTextType.body,
                             color = CustomColor.gray300,
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         CustomText(
                             text = "비밀번호 찾기",
-                            type = CustomTextType.bodyMedium,
+                            type = CustomTextType.body,
                             color = CustomColor.black,
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         CustomText(
                             text = " | ",
-                            type = CustomTextType.bodyMedium,
+                            type = CustomTextType.body,
                             color = CustomColor.gray300,
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         CustomText(
                             text = "회원가입",
-                            type = CustomTextType.bodyMedium,
+                            type = CustomTextType.body,
                             color = CustomColor.black,
                             modifier = Modifier.clickable {
                                 navController.navigate(Screen.SignUp.route)
@@ -309,7 +309,7 @@ fun LoginScreen(navController: NavController) {
                 Spacer(modifier = Modifier.width(10.dp))
                 CustomText(
                     text = "SNS 계정으로 로그인",
-                    type = CustomTextType.bodyMedium,
+                    type = CustomTextType.body,
                     color = CustomColor.gray300,
                     modifier = Modifier.align(Alignment.CenterVertically)
                 )
@@ -351,19 +351,19 @@ fun LoginScreen(navController: NavController) {
             ) {
                 CustomText(
                     text = "이용약관",
-                    type = CustomTextType.bodyMedium,
+                    type = CustomTextType.body,
                     color = CustomColor.black,
                 )
                 Spacer(modifier = Modifier.width(16.dp))
                 CustomText(
                     text = " | ",
-                    type = CustomTextType.bodyMedium,
+                    type = CustomTextType.body,
                     color = CustomColor.gray300,
                 )
                 Spacer(modifier = Modifier.width(16.dp))
                 CustomText(
                     text = "개인정보 보호정책",
-                    type = CustomTextType.bodyMedium,
+                    type = CustomTextType.body,
                     color = CustomColor.black,
                 )
             }

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoCompleteScreen.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoCompleteScreen.kt
@@ -69,19 +69,19 @@ fun RequiredInfoCompleteScreen(navController: NavController) {
                 }
                 CustomText(
                     text = "신청이 완료되었습니다",
-                    type = CustomTextType.titleLarge,
+                    type = CustomTextType.title,
                     size = 24.sp,
                     textAlign = TextAlign.Center
                 )
                 CustomText(
                     text = ". . .",
-                    type = CustomTextType.titleLarge,
+                    type = CustomTextType.title,
                     color = CustomColor.gray400,
                     textAlign = TextAlign.Center
                 )
                 CustomText(
                     text = "심사 중입니다",
-                    type = CustomTextType.bodyLarge,
+                    type = CustomTextType.body,
                     color = CustomColor.gray400,
                     textAlign = TextAlign.Center
                 )
@@ -102,7 +102,7 @@ fun RequiredInfoCompleteScreen(navController: NavController) {
                 ) {
                     CustomText(
                         text = "심사는 약 일주일 정도 걸립니다.\n심사가 완료되면 매칭이 시작됩니다!",
-                        type = CustomTextType.bodyMedium,
+                        type = CustomTextType.body,
                         color = CustomColor.gray400,
                         textAlign = TextAlign.Start
                     )
@@ -121,7 +121,7 @@ fun RequiredInfoCompleteScreen(navController: NavController) {
                 ) {
                     CustomText(
                         text = "확인했어요",
-                        type = CustomTextType.bodyMedium,
+                        type = CustomTextType.body,
                         color = Color.Black
                     )
                 }

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoCompleteScreen.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoCompleteScreen.kt
@@ -2,19 +2,30 @@ package com.apptive.japkor.ui.requiredinfo
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.apptive.japkor.navigation.Screen
 import com.apptive.japkor.ui.components.CustomText
@@ -34,34 +45,89 @@ fun RequiredInfoCompleteScreen(navController: NavController) {
                 .fillMaxSize()
                 .padding(innerPadding)
                 .padding(horizontal = 32.dp),
-            verticalArrangement = Arrangement.Center,
+            verticalArrangement = Arrangement.SpaceBetween,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            CustomText(
-                text = "신청이 완료되었어요!",
-                type = CustomTextType.mainBoldSmall
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            CustomText(
-                text = "곧 연결 결과를 알려드릴게요.",
-                type = CustomTextType.bodyLarge,
-                color = CustomColor.gray400
-            )
-            Spacer(modifier = Modifier.height(32.dp))
-            Button(
-                onClick = {
-                    navController.navigate(Screen.Language.route) {
-                        popUpTo(Screen.Language.route) { inclusive = false }
-                    }
-                },
-                colors = ButtonDefaults.buttonColors(containerColor = CustomColor.gray300)
+            Spacer(modifier = Modifier.height(48.dp))
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
+                Box(
+                    modifier = Modifier
+                        .size(88.dp)
+                        .background(color = CustomColor.gray100, shape = CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = "완료",
+                        tint = CustomColor.black,
+                        modifier = Modifier.size(40.dp)
+                    )
+                }
                 CustomText(
-                    text = "확인",
+                    text = "신청이 완료되었습니다",
+                    type = CustomTextType.titleLarge,
+                    size = 24.sp,
+                    textAlign = TextAlign.Center
+                )
+                CustomText(
+                    text = ". . .",
+                    type = CustomTextType.titleLarge,
+                    color = CustomColor.gray400,
+                    textAlign = TextAlign.Center
+                )
+                CustomText(
+                    text = "심사 중입니다",
                     type = CustomTextType.bodyLarge,
-                    color = Color.Black
+                    color = CustomColor.gray400,
+                    textAlign = TextAlign.Center
                 )
             }
+
+
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 8.dp, bottom = 8.dp),
+                    contentAlignment = Alignment.BottomStart
+                ) {
+                    CustomText(
+                        text = "심사는 약 일주일 정도 걸립니다.\n심사가 완료되면 매칭이 시작됩니다!",
+                        type = CustomTextType.bodyMedium,
+                        color = CustomColor.gray400,
+                        textAlign = TextAlign.Start
+                    )
+                }
+
+                Button(
+                    onClick = {
+                        navController.navigate(Screen.Language.route) {
+                            popUpTo(Screen.Language.route) { inclusive = false }
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(containerColor = CustomColor.gray300),
+                    shape = RoundedCornerShape(16.dp),
+                    contentPadding = PaddingValues(vertical = 16.dp)
+                ) {
+                    CustomText(
+                        text = "확인했어요",
+                        type = CustomTextType.bodyMedium,
+                        color = Color.Black
+                    )
+                }
+
+            }
+            Spacer(modifier = Modifier.height(24.dp))
         }
     }
 }

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoCompleteScreen.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoCompleteScreen.kt
@@ -1,0 +1,67 @@
+package com.apptive.japkor.ui.requiredinfo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.apptive.japkor.navigation.Screen
+import com.apptive.japkor.ui.components.CustomText
+import com.apptive.japkor.ui.components.CustomTextType
+import com.apptive.japkor.ui.theme.CustomColor
+
+@Composable
+fun RequiredInfoCompleteScreen(navController: NavController) {
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White),
+        containerColor = Color.White
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 32.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            CustomText(
+                text = "신청이 완료되었어요!",
+                type = CustomTextType.mainBoldSmall
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            CustomText(
+                text = "곧 연결 결과를 알려드릴게요.",
+                type = CustomTextType.bodyLarge,
+                color = CustomColor.gray400
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            Button(
+                onClick = {
+                    navController.navigate(Screen.Language.route) {
+                        popUpTo(Screen.Language.route) { inclusive = false }
+                    }
+                },
+                colors = ButtonDefaults.buttonColors(containerColor = CustomColor.gray300)
+            ) {
+                CustomText(
+                    text = "확인",
+                    type = CustomTextType.bodyLarge,
+                    color = Color.Black
+                )
+            }
+        }
+    }
+}

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
@@ -155,7 +155,7 @@ fun RequiredInfoScreen(
                     shape = RoundedCornerShape(16.dp)
                 ) {
                     CustomText(
-                        text = if (currentStep.value < 4) "다음" else "완료",
+                        text = if (currentStep.value < 5) "다음" else "완료",
                         type = CustomTextType.bodyLarge,
                         color = Color.Black
                     )

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
@@ -4,26 +4,32 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -47,123 +53,140 @@ fun RequiredInfoScreen(
     val selectedOption = remember { mutableStateOf("한국 남성") }
     val currentStep = remember { mutableStateOf(initialStep) }
 
-    Column(
+    Scaffold(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.White)
-            .padding(WindowInsets.safeDrawing.asPaddingValues()),
-        horizontalAlignment = Alignment.Start
-    ) {
-        // 상단 뒤로가기
-        Spacer(modifier = Modifier.height(30.dp))
-        Column(
-            modifier = Modifier
-                .fillMaxWidth(),
-            horizontalAlignment = Alignment.Start
-        ) {
-            IconButton(
-                onClick = { navController.popBackStack() },
-                modifier = Modifier.padding(horizontal = 20.dp)
+            .background(Color.White),
+        containerColor = Color.White,
+        contentWindowInsets = WindowInsets.safeDrawing,
+        bottomBar = {
+            Surface(
+                color = Color.White,
+                tonalElevation = 4.dp,
+                shadowElevation = 8.dp
             ) {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_back),
-                    contentDescription = "뒤로가기",
-                )
-            }
-        }
-
-        // 스텝 인디케이터 (4단계, 높이 3dp)
-        StepIndicator(currentStep = currentStep.value, totalSteps = 5)
-        Spacer(modifier = Modifier.height(24.dp))
-
-        // Step에 따른 Body UI
-        when (currentStep.value) {
-            1 -> Step1Content(selectedOption = selectedOption)
-            2 -> Step2Content()
-            3 -> Step3Content()
-            4 -> Step4Content()
-            5 -> Step5Content()
-        }
-
-        // 하단 버튼
-        Spacer(modifier = Modifier.weight(1f)) // Pushes the buttons to the bottom
-        if (currentStep.value == 1) {
-            // Step 1: 다음 버튼만
-            Button(
-                onClick = {
-                    currentStep.value += 1
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(50.dp)
-                    .padding(horizontal = 30.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = CustomColor.gray300
-                ),
-                shape = RoundedCornerShape(16.dp)
-            ) {
-                CustomText(
-                    text = "다음",
-                    type = CustomTextType.bodyLarge,
-                    color = Color.Black
-                )
-            }
-        } else {
-            // Step 2, 3, 4: 이전, 다음/완료 버튼
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 30.dp),
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                // 이전 버튼
-                Button(
-                    onClick = {
-                        currentStep.value -= 1
-                    },
+                Column(
                     modifier = Modifier
-                        .weight(1f)
-                        .height(50.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = CustomColor.gray100
-                    ),
-                    shape = RoundedCornerShape(16.dp)
+                        .fillMaxWidth()
+                        .navigationBarsPadding()
+                        .padding(horizontal = 30.dp, vertical = 16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    CustomText(
-                        text = "이전",
-                        type = CustomTextType.bodyLarge,
-                        color = CustomColor.black
-                    )
-                }
-
-                // 다음/완료 버튼
-                Button(
-                    onClick = {
-                        if (currentStep.value < 5) {
-                            currentStep.value += 1
-                        } else {
-                            // 마지막 단계에서 완료 처리
-                            navController.navigate("language") // 다음 화면으로 이동
+                    if (currentStep.value == 1) {
+                        Button(
+                            onClick = { currentStep.value += 1 },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(50.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = CustomColor.gray300
+                            ),
+                            shape = RoundedCornerShape(16.dp)
+                        ) {
+                            CustomText(
+                                text = "다음",
+                                type = CustomTextType.bodyLarge,
+                                color = Color.Black
+                            )
                         }
-                    },
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(50.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = CustomColor.gray300
-                    ),
-                    shape = RoundedCornerShape(16.dp)
-                ) {
-                    CustomText(
-                        text = if (currentStep.value < 5) "다음" else "완료",
-                        type = CustomTextType.bodyLarge,
-                        color = Color.Black
-                    )
+                    } else {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(16.dp)
+                        ) {
+                            Button(
+                                onClick = { currentStep.value -= 1 },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .height(50.dp),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = CustomColor.gray100
+                                ),
+                                shape = RoundedCornerShape(16.dp)
+                            ) {
+                                CustomText(
+                                    text = "이전",
+                                    type = CustomTextType.bodyLarge,
+                                    color = CustomColor.black
+                                )
+                            }
+
+                            Button(
+                                onClick = {
+                                    if (currentStep.value < 5) {
+                                        currentStep.value += 1
+                                    } else {
+                                        navController.navigate("language")
+                                    }
+                                },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .height(50.dp),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = CustomColor.gray300
+                                ),
+                                shape = RoundedCornerShape(16.dp)
+                            ) {
+                                CustomText(
+                                    text = if (currentStep.value < 5) "다음" else "완료",
+                                    type = CustomTextType.bodyLarge,
+                                    color = Color.Black
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }
+    ) { innerPadding ->
+        val layoutDirection = LocalLayoutDirection.current
+        val contentPadding = PaddingValues(
+            start = innerPadding.calculateStartPadding(layoutDirection),
+            end = innerPadding.calculateEndPadding(layoutDirection),
+            top = innerPadding.calculateTopPadding(),
+            bottom = innerPadding.calculateBottomPadding() + 24.dp
+        )
 
-        Spacer(modifier = Modifier.navigationBarsPadding())
-
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.White),
+            contentPadding = contentPadding
+        ) {
+            item {
+                Spacer(modifier = Modifier.height(30.dp))
+            }
+            item {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.Start
+                ) {
+                    IconButton(
+                        onClick = { navController.popBackStack() },
+                        modifier = Modifier.padding(horizontal = 20.dp)
+                    ) {
+                        Image(
+                            painter = painterResource(id = R.drawable.ic_back),
+                            contentDescription = "뒤로가기",
+                        )
+                    }
+                }
+            }
+            item {
+                StepIndicator(currentStep = currentStep.value, totalSteps = 5)
+            }
+            item {
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+            item {
+                when (currentStep.value) {
+                    1 -> Step1Content(selectedOption = selectedOption)
+                    2 -> Step2Content()
+                    3 -> Step3Content()
+                    4 -> Step4Content()
+                    5 -> Step5Content()
+                }
+            }
+        }
     }
 }

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
@@ -86,7 +86,7 @@ fun RequiredInfoScreen(
                         ) {
                             CustomText(
                                 text = "다음",
-                                type = CustomTextType.bodyLarge,
+                                type = CustomTextType.body,
                                 color = Color.Black
                             )
                         }
@@ -107,7 +107,7 @@ fun RequiredInfoScreen(
                             ) {
                                 CustomText(
                                     text = "이전",
-                                    type = CustomTextType.bodyLarge,
+                                    type = CustomTextType.body,
                                     color = CustomColor.black
                                 )
                             }
@@ -130,7 +130,7 @@ fun RequiredInfoScreen(
                             ) {
                                 CustomText(
                                     text = if (currentStep.value < 5) "다음" else "완료",
-                                    type = CustomTextType.bodyLarge,
+                                    type = CustomTextType.body,
                                     color = Color.Black
                                 )
                             }

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.apptive.japkor.navigation.Screen
 import com.apptive.japkor.R
 import com.apptive.japkor.ui.components.CustomText
 import com.apptive.japkor.ui.components.CustomTextType
@@ -116,7 +117,7 @@ fun RequiredInfoScreen(
                                     if (currentStep.value < 5) {
                                         currentStep.value += 1
                                     } else {
-                                        navController.navigate("language")
+                                        navController.navigate(Screen.RequiredInfoComplete.route)
                                     }
                                 },
                                 modifier = Modifier

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step1Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step1Content.kt
@@ -32,13 +32,13 @@ fun Step1Content(selectedOption: MutableState<String>) {
     ) {
         CustomText(
             text = "성별을 설정해주세요",
-            type = CustomTextType.mainRegularLarge,
+            type = CustomTextType.mainRegular,
             size = 32.sp
         )
         CustomText(
             text = "한국인 남성, 일본인 여성 중 선택가능합니다.",
             color = CustomColor.gray400,
-            type = CustomTextType.mainRegularSmall,
+            type = CustomTextType.mainRegular,
         )
         Spacer(modifier = Modifier.height(50.dp))
 
@@ -50,7 +50,7 @@ fun Step1Content(selectedOption: MutableState<String>) {
             CustomText(
                 text = "저는",
                 color = CustomColor.gray400,
-                type = CustomTextType.mainRegularSmall,
+                type = CustomTextType.mainRegular,
             )
             Spacer(modifier = Modifier.width(10.dp))
             Column {
@@ -66,7 +66,7 @@ fun Step1Content(selectedOption: MutableState<String>) {
                         CustomText(
                             text = option,
                             color = if (isSelected) Color.White else CustomColor.black,
-                            type = CustomTextType.mainRegularSmall,
+                            type = CustomTextType.mainRegular,
                         )
                     }
                 }
@@ -75,7 +75,7 @@ fun Step1Content(selectedOption: MutableState<String>) {
             CustomText(
                 text = "입니다.",
                 color = CustomColor.gray400,
-                type = CustomTextType.mainRegularSmall,
+                type = CustomTextType.mainRegular,
             )
         }
         Spacer(modifier = Modifier.height(80.dp))
@@ -87,7 +87,7 @@ fun Step1Content(selectedOption: MutableState<String>) {
         CustomText(
             text = selectedText,
             color = CustomColor.gray300,
-            type = CustomTextType.bodyLarge,
+            type = CustomTextType.body,
             size = 14.sp
         )
         Spacer(modifier = Modifier.height(30.dp))

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step1Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step1Content.kt
@@ -88,6 +88,7 @@ fun Step1Content(selectedOption: MutableState<String>) {
             text = selectedText,
             color = CustomColor.gray300,
             type = CustomTextType.bodyLarge,
+            size = 14.sp
         )
         Spacer(modifier = Modifier.height(30.dp))
     }

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step2Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step2Content.kt
@@ -78,10 +78,11 @@ fun Step2Content() {
         }
 
         CustomText(
-            text = "거짓 정보 입력시, 큰일남!!",
+            text = "거짓 정보 입력 시 서비스 이용이 제한될 수 있습니다.",
             color = CustomColor.gray300,
             type = CustomTextType.bodyLarge,
-            modifier = Modifier.padding(horizontal = 7.dp)
+            modifier = Modifier.padding(horizontal = 7.dp),
+            size = 14.sp
         )
 
     }

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step2Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step2Content.kt
@@ -35,13 +35,13 @@ fun Step2Content() {
     ) {
         CustomText(
             text = "필수정보입력",
-            type = CustomTextType.mainRegularLarge,
+            type = CustomTextType.mainRegular,
             size = 32.sp
         )
         CustomText(
             text = "클릭하여 각 항목에 정보를 입력해주세요.",
             color = CustomColor.gray400,
-            type = CustomTextType.mainRegularSmall,
+            type = CustomTextType.mainRegular,
         )
         Spacer(modifier = Modifier.height(5.dp))
 
@@ -53,7 +53,7 @@ fun Step2Content() {
         ) {
             CustomText(
                 text = "*필수 항목",
-                type = CustomTextType.bodyLarge,
+                type = CustomTextType.body,
                 color = CustomColor.gray300
             )
         }
@@ -77,7 +77,7 @@ fun Step2Content() {
         CustomText(
             text = "거짓 정보 입력 시 서비스 이용이 제한될 수 있습니다.",
             color = CustomColor.gray300,
-            type = CustomTextType.bodyLarge,
+            type = CustomTextType.body,
             modifier = Modifier.padding(horizontal = 7.dp),
             size = 14.sp
         )

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step2Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step2Content.kt
@@ -9,9 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,7 +29,6 @@ fun Step2Content() {
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 50.dp)
-            .verticalScroll(rememberScrollState())
             .imePadding(),
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(16.dp)

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step3Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step3Content.kt
@@ -30,13 +30,13 @@ fun Step3Content() {
     ) {
         CustomText(
             text = "선택사항",
-            type = CustomTextType.mainRegularLarge,
+            type = CustomTextType.mainRegular,
             size = 32.sp
         )
         CustomText(
             text = "클릭하여 각 항목에 정보를 입력해주세요.",
             color = CustomColor.gray400,
-            type = CustomTextType.mainRegularSmall,
+            type = CustomTextType.mainRegular,
         )
         Spacer(modifier = Modifier.height(50.dp))
 
@@ -69,7 +69,7 @@ fun Step3Content() {
         CustomText(
             text = "'학력' 및 '재산' 정보는 선택 입력 사항입니다.\n입력시, 더 빠르고 정확한 매칭에 도움을 줄 수 있습니다.",
             color = CustomColor.gray300,
-            type = CustomTextType.bodyLarge,
+            type = CustomTextType.body,
             modifier = Modifier.padding(horizontal = 7.dp),
             size = 14.sp
         )

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step3Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step3Content.kt
@@ -70,7 +70,8 @@ fun Step3Content() {
             text = "'학력' 및 '재산' 정보는 선택 입력 사항입니다.\n입력시, 더 빠르고 정확한 매칭에 도움을 줄 수 있습니다.",
             color = CustomColor.gray300,
             type = CustomTextType.bodyLarge,
-            modifier = Modifier.padding(horizontal = 7.dp)
+            modifier = Modifier.padding(horizontal = 7.dp),
+            size = 14.sp
         )
     }
 }

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step4Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step4Content.kt
@@ -48,7 +48,7 @@ fun Step4Content() {
             color = CustomColor.gray300,
             type = CustomTextType.bodyLarge,
             modifier = Modifier.padding(horizontal = 7.dp),
-            size = 16.sp
+            size = 14.sp
         )
 
         CustomText(
@@ -56,13 +56,15 @@ fun Step4Content() {
             color = CustomColor.gray400,
             type = CustomTextType.bodyLarge,
             modifier = Modifier.padding(horizontal = 7.dp),
+            size = 14.sp
         )
 
         CustomText(
             text = "- 과도한 포토샵/스티커, 마스크로 가린 사진, 똑같은 사진 2장 등 가이드에 벗어나는 사진은 가입이 거절될 수 있습니다.",
             color = CustomColor.gray300,
             type = CustomTextType.bodyLarge,
-            modifier = Modifier.padding(horizontal = 7.dp)
+            modifier = Modifier.padding(horizontal = 7.dp),
+            size = 14.sp
         )
 
 
@@ -73,11 +75,12 @@ fun Step4Content() {
             underline = true,
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
-                .padding(vertical = 12.dp)
+                .padding(vertical = 14.dp)
                 .clickable(
                     role = Role.Button,
                     onClick = { /* TODO: 사진 가이드 보기 */ }
-                )
+                ),
+            size = 14.sp
         )
     }
 }

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step4Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step4Content.kt
@@ -1,31 +1,21 @@
 package com.apptive.japkor.ui.requiredinfo.steps
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.apptive.japkor.ui.components.CustomText
 import com.apptive.japkor.ui.components.CustomTextType
+import com.apptive.japkor.ui.components.step4.PhotoUploadGrid
 import com.apptive.japkor.ui.theme.CustomColor
 
 @Composable
@@ -51,13 +41,14 @@ fun Step4Content() {
 
         PhotoUploadGrid()
 
-        Spacer(modifier = Modifier.height(5.dp))
+
 
         CustomText(
             text = "- 사진은 프로필에서 가장 중요한 요소입니다.",
             color = CustomColor.gray300,
             type = CustomTextType.bodyLarge,
-            modifier = Modifier.padding(horizontal = 7.dp)
+            modifier = Modifier.padding(horizontal = 7.dp),
+            size = 16.sp
         )
 
         CustomText(
@@ -74,7 +65,7 @@ fun Step4Content() {
             modifier = Modifier.padding(horizontal = 7.dp)
         )
 
-        Spacer(modifier = Modifier.height(85.dp))
+
         CustomText(
             text = "프로필 사진 가이드 보기",
             color = CustomColor.gray300,
@@ -92,63 +83,6 @@ fun Step4Content() {
 }
 
 // 3열 그리드 (간격/패딩/정사각형 유지)
-@Composable
-fun PhotoUploadGrid() {
-    Column(modifier = Modifier.fillMaxWidth()) {
-        val cells = (0 until 6).toList()
-        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            cells.chunked(3).forEach { row ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(10.dp)
-                ) {
-                    row.forEach { idx ->
-                        UploadPhotoCard(
-                            modifier = Modifier
-                                .weight(1f)
-                                .aspectRatio(1f),   // 정사각형
-                            onClick = { /* TODO: photo pick for idx */ }
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
+
 
 // 카드 1칸 (화이트 카드 + 소프트 섀도우 + 중앙 원형 + 아이콘)
-@Composable
-fun UploadPhotoCard(
-    modifier: Modifier = Modifier,
-    onClick: () -> Unit = {}
-) {
-    val shape = RoundedCornerShape(10.dp)
-
-    // 바탕 카드 (soft shadow)
-    Box(
-        modifier = modifier
-            .shadow(2.dp, shape, clip = false)
-            .clip(shape)
-            .background(Color.White)
-            .clickable(onClick = onClick),
-        contentAlignment = Alignment.Center
-    ) {
-        // 가운데 옅은 원 + '+' 아이콘
-        Box(
-            modifier = Modifier
-                .size(25.dp)                          // 원 크기
-                .background(
-                    color = Color(0xFFF5F6F8),        // 연한 회색 배경
-                    shape = CircleShape
-                ),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = "+",
-                fontSize = 22.sp,
-                color = Color(0xFFB8BDC7)            // 아이콘 컬러
-            )
-        }
-    }
-}

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step4Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step4Content.kt
@@ -29,13 +29,13 @@ fun Step4Content() {
     ) {
         CustomText(
             text = "프로필사진",
-            type = CustomTextType.mainRegularLarge,
+            type = CustomTextType.mainRegular,
             size = 32.sp
         )
         CustomText(
             text = "클릭하여 얼굴이 보이는 사진을 첨부해주세요.",
             color = CustomColor.gray400,
-            type = CustomTextType.mainRegularSmall,
+            type = CustomTextType.mainRegular,
         )
         Spacer(modifier = Modifier.height(5.dp))
 
@@ -46,7 +46,7 @@ fun Step4Content() {
         CustomText(
             text = "- 사진은 프로필에서 가장 중요한 요소입니다.",
             color = CustomColor.gray300,
-            type = CustomTextType.bodyLarge,
+            type = CustomTextType.body,
             modifier = Modifier.padding(horizontal = 7.dp),
             size = 14.sp
         )
@@ -54,7 +54,7 @@ fun Step4Content() {
         CustomText(
             text = "- 얼굴 정면이 잘 보이는 사진으로 최소 2장 이상 올려주세요.",
             color = CustomColor.gray400,
-            type = CustomTextType.bodyLarge,
+            type = CustomTextType.body,
             modifier = Modifier.padding(horizontal = 7.dp),
             size = 14.sp
         )
@@ -62,7 +62,7 @@ fun Step4Content() {
         CustomText(
             text = "- 과도한 포토샵/스티커, 마스크로 가린 사진, 똑같은 사진 2장 등 가이드에 벗어나는 사진은 가입이 거절될 수 있습니다.",
             color = CustomColor.gray300,
-            type = CustomTextType.bodyLarge,
+            type = CustomTextType.body,
             modifier = Modifier.padding(horizontal = 7.dp),
             size = 14.sp
         )
@@ -71,7 +71,7 @@ fun Step4Content() {
         CustomText(
             text = "프로필 사진 가이드 보기",
             color = CustomColor.gray300,
-            type = CustomTextType.bodyLarge,
+            type = CustomTextType.body,
             underline = true,
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step5Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step5Content.kt
@@ -7,9 +7,7 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -60,11 +58,9 @@ fun Step5Content() {
     val personalityMax = 3
     val visualMax = 5
     val dateStyleMax = 5
-    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .verticalScroll(scrollState)
             .padding(horizontal = 50.dp),
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(16.dp)

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step5Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step5Content.kt
@@ -2,11 +2,20 @@ package com.apptive.japkor.ui.requiredinfo.steps
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -15,33 +24,188 @@ import com.apptive.japkor.ui.components.CustomText
 import com.apptive.japkor.ui.components.CustomTextType
 import com.apptive.japkor.ui.theme.CustomColor
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun Step5Content() {
+    val personalityList = listOf(
+        "열정적인", "개성있는", "차분한", "낙천적인", "유머있는", "섬세한", "지적인", "듬직한", "외향적인", "내향적인"
+    )
+    val visualList = listOf(
+        "손이 예쁜 사람",
+        "예의 바른 사람",
+        "운동 좋아하는 사람",
+        "책 읽는 사람",
+        "음악 좋아하는 사람",
+        "요리 잘하는 사람",
+        "패션 센스 있는 사람",
+        "애교 많은 사람",
+        "대화 잘 통하는 사람",
+        "취미 생활이 다양한 사람"
+    )
+    val dateStyleList = listOf(
+        "산책 데이트",
+        "카페 데이트",
+        "영화관 데이트",
+        "집 데이트",
+        "여행 데이트",
+        "운동 데이트",
+        "전시회 데이트",
+        "음악 감상 데이트",
+        "맛집 탐방 데이트",
+        "드라이브 데이트"
+    )
+    var selectedvisuals by remember { mutableStateOf(setOf<String>()) }
+    var selectedPersonalities by remember { mutableStateOf(setOf<String>()) }
+    var selectedDateStyles by remember { mutableStateOf(setOf<String>()) }
+    val personalityMax = 3
+    val visualMax = 5
+    val dateStyleMax = 5
+    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .verticalScroll(scrollState)
             .padding(horizontal = 50.dp),
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        CustomText(
-            text = "나의 성격",
-            type = CustomTextType.mainRegularLarge,
-            size = 16.sp
-        )
-        CustomText(
-            text = "성격, 이상형, 데이트 스타일 등등",
-            color = CustomColor.gray400,
-            type = CustomTextType.mainRegularSmall,
-        )
-        Spacer(modifier = Modifier.height(50.dp))
-
-        // 자기소개 작성 UI 구현 (예시)
-        CustomText(
-            text = "Step 5: 화면",
-            color = CustomColor.gray300,
-            type = CustomTextType.bodyLarge,
-        )
-        Spacer(modifier = Modifier.height(200.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            CustomText(
+                text = "나의 성격",
+                type = CustomTextType.mainBoldSmall,
+                size = 16.sp
+            )
+            CustomText(
+                text = "(3개 이하)",
+                type = CustomTextType.mainBoldSmall,
+                size = 14.sp,
+                color = CustomColor.gray300
+            )
+        }
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            personalityList.forEach { personality ->
+                val isSelected = selectedPersonalities.contains(personality)
+                val buttonContainerColor =
+                    if (isSelected) CustomColor.gray300 else CustomColor.gray100
+                val buttonContentColor = if (isSelected) CustomColor.black else CustomColor.gray400
+                Surface(
+                    onClick = {
+                        selectedPersonalities = if (isSelected) {
+                            selectedPersonalities - personality
+                        } else {
+                            if (selectedPersonalities.size < personalityMax) selectedPersonalities + personality else selectedPersonalities
+                        }
+                    },
+                    color = buttonContainerColor,
+                    contentColor = buttonContentColor,
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    CustomText(
+                        text = personality,
+                        type = CustomTextType.bodyLarge,
+                        size = 12.sp,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
+                    )
+                }
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            CustomText(
+                text = "이상형",
+                type = CustomTextType.mainBoldSmall,
+                size = 16.sp
+            )
+            CustomText(
+                text = "(5개 이하)",
+                type = CustomTextType.mainBoldSmall,
+                size = 14.sp,
+                color = CustomColor.gray300
+            )
+        }
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            visualList.forEach { visual ->
+                val isSelected = selectedvisuals.contains(visual)
+                val buttonContainerColor =
+                    if (isSelected) CustomColor.gray300 else CustomColor.gray100
+                val buttonContentColor = if (isSelected) CustomColor.black else CustomColor.gray400
+                Surface(
+                    onClick = {
+                        selectedvisuals = if (isSelected) {
+                            selectedvisuals - visual
+                        } else {
+                            if (selectedvisuals.size < visualMax) selectedvisuals + visual else selectedvisuals
+                        }
+                    },
+                    color = buttonContainerColor,
+                    contentColor = buttonContentColor,
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    CustomText(
+                        text = visual,
+                        type = CustomTextType.bodyLarge,
+                        size = 12.sp,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
+                    )
+                }
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            CustomText(
+                text = "데이트 스타일",
+                type = CustomTextType.mainBoldSmall,
+                size = 16.sp
+            )
+            CustomText(
+                text = "(5개 이하)",
+                type = CustomTextType.mainBoldSmall,
+                size = 14.sp,
+                color = CustomColor.gray300
+            )
+        }
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            dateStyleList.forEach { style ->
+                val isSelected = selectedDateStyles.contains(style)
+                val buttonContainerColor =
+                    if (isSelected) CustomColor.gray300 else CustomColor.gray100
+                val buttonContentColor = if (isSelected) CustomColor.black else CustomColor.gray400
+                Surface(
+                    onClick = {
+                        selectedDateStyles = if (isSelected) {
+                            selectedDateStyles - style
+                        } else {
+                            if (selectedDateStyles.size < dateStyleMax) selectedDateStyles + style else selectedDateStyles
+                        }
+                    },
+                    color = buttonContainerColor,
+                    contentColor = buttonContentColor,
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    CustomText(
+                        text = style,
+                        type = CustomTextType.bodyLarge,
+                        size = 12.sp,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
+                    )
+                }
+            }
+        }
     }
 }

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step5Content.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step5Content.kt
@@ -71,12 +71,12 @@ fun Step5Content() {
         ) {
             CustomText(
                 text = "나의 성격",
-                type = CustomTextType.mainBoldSmall,
+                type = CustomTextType.mainBold,
                 size = 16.sp
             )
             CustomText(
                 text = "(3개 이하)",
-                type = CustomTextType.mainBoldSmall,
+                type = CustomTextType.mainBold,
                 size = 14.sp,
                 color = CustomColor.gray300
             )
@@ -104,7 +104,7 @@ fun Step5Content() {
                 ) {
                     CustomText(
                         text = personality,
-                        type = CustomTextType.bodyLarge,
+                        type = CustomTextType.body,
                         size = 12.sp,
                         modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
                     )
@@ -117,12 +117,12 @@ fun Step5Content() {
         ) {
             CustomText(
                 text = "이상형",
-                type = CustomTextType.mainBoldSmall,
+                type = CustomTextType.mainBold,
                 size = 16.sp
             )
             CustomText(
                 text = "(5개 이하)",
-                type = CustomTextType.mainBoldSmall,
+                type = CustomTextType.mainBold,
                 size = 14.sp,
                 color = CustomColor.gray300
             )
@@ -150,7 +150,7 @@ fun Step5Content() {
                 ) {
                     CustomText(
                         text = visual,
-                        type = CustomTextType.bodyLarge,
+                        type = CustomTextType.body,
                         size = 12.sp,
                         modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
                     )
@@ -163,12 +163,12 @@ fun Step5Content() {
         ) {
             CustomText(
                 text = "데이트 스타일",
-                type = CustomTextType.mainBoldSmall,
+                type = CustomTextType.mainBold,
                 size = 16.sp
             )
             CustomText(
                 text = "(5개 이하)",
-                type = CustomTextType.mainBoldSmall,
+                type = CustomTextType.mainBold,
                 size = 14.sp,
                 color = CustomColor.gray300
             )
@@ -196,7 +196,7 @@ fun Step5Content() {
                 ) {
                     CustomText(
                         text = style,
-                        type = CustomTextType.bodyLarge,
+                        type = CustomTextType.body,
                         size = 12.sp,
                         modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
                     )

--- a/frontend/app/src/main/java/com/apptive/japkor/ui/signup/SignUpScreen.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/ui/signup/SignUpScreen.kt
@@ -97,7 +97,7 @@ fun SignUpScreen(navController: NavController) {
                 ) {
                     CustomText(
                         text = "한국어",
-                        type = CustomTextType.bodyLarge,
+                        type = CustomTextType.body,
                         color = CustomColor.gray300,
                         underline = true
                     )
@@ -115,13 +115,13 @@ fun SignUpScreen(navController: NavController) {
             ) {
                 CustomText(
                     text = "회원가입",
-                    type = CustomTextType.mainRegularLarge,
+                    type = CustomTextType.mainRegular,
                     size = 32.sp
                 )
                 CustomText(
                     text = "당신의 인연을 잇는 소개팅 어플 '앤'에 가입하세요\n",
                     color = CustomColor.gray400,
-                    type = CustomTextType.mainRegularSmall,
+                    type = CustomTextType.mainRegular,
                 )
 
                 Column(
@@ -219,7 +219,7 @@ fun SignUpScreen(navController: NavController) {
                     ) {
                         CustomText(
                             text = "회원가입",
-                            type = CustomTextType.bodyLarge,
+                            type = CustomTextType.body,
                             color = Color.Black
                         )
                     }

--- a/frontend/app/src/main/java/com/apptive/japkor/utils/ToastExtensions.kt
+++ b/frontend/app/src/main/java/com/apptive/japkor/utils/ToastExtensions.kt
@@ -1,0 +1,28 @@
+package com.apptive.japkor.utils
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.apptive.japkor.ui.components.CustomToast
+
+/**
+ * Convenience helpers so any module can trigger app-styled toasts quickly.
+ */
+fun Context.toast(message: String) {
+    CustomToast.show(this, message)
+}
+
+fun Context.toast(@StringRes messageRes: Int) {
+    CustomToast.show(this, messageRes)
+}
+
+fun Context.successToast(message: String, long: Boolean = false) {
+    CustomToast.showSuccess(this, message, long)
+}
+
+fun Context.errorToast(message: String, long: Boolean = false) {
+    CustomToast.showError(this, message, long)
+}
+
+fun Context.debugToast(message: String, long: Boolean = false) {
+    CustomToast.showDebug(this, message, long)
+}

--- a/frontend/app/src/main/res/drawable/bg_custom_toast.xml
+++ b/frontend/app/src/main/res/drawable/bg_custom_toast.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <corners android:radius="16dp" />
+
+    <solid android:color="@color/toast_background" />
+
+    <stroke
+        android:width="1dp"
+        android:color="@color/toast_border" />
+
+</shape>

--- a/frontend/app/src/main/res/layout/view_custom_toast.xml
+++ b/frontend/app/src/main/res/layout/view_custom_toast.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:background="@drawable/bg_custom_toast"
+    android:paddingStart="20dp"
+    android:paddingEnd="20dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp"
+    android:minWidth="180dp"
+    android:elevation="6dp"
+    android:clipToPadding="false"
+    android:layout_margin="8dp">
+
+    <TextView
+        android:id="@+id/toast_message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/toast_text"
+        android:textSize="14sp"
+        android:fontFamily="@font/pretendard_medium"
+        android:lineSpacingExtra="2dp"
+        android:letterSpacing="0.01"
+        android:maxLines="3"
+        android:ellipsize="end"
+        android:textAlignment="viewStart"
+        android:text="" />
+
+</LinearLayout>

--- a/frontend/app/src/main/res/values/dimens.xml
+++ b/frontend/app/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="toast_vertical_offset">72dp</dimen>
+</resources>


### PR DESCRIPTION
# 작업내용

- step4 여백 조절 및  텍스트 크기 조절 , 컴포넌트 분리 작업
- step5 페이지 추가
- 하단 바텀 버튼 고정
- 완료 페이지 추가
- CustomText 컴포넌트 개선

## 스크린샷
 
<img width=30% alt="스크린샷 2025-10-16 오후 11 03 00" src="https://github.com/user-attachments/assets/d78331bf-b02e-4f60-8c96-79e23112026d" />

<img width=30% alt="스크린샷 2025-10-16 오후 11 01 57" src="https://github.com/user-attachments/assets/65bd90bd-f216-4340-86a5-3dbdc5538edf" />
<img width=30% alt="스크린샷 2025-10-16 오후 11 02 09" src="https://github.com/user-attachments/assets/cd217e3b-24f2-4ec2-8ee7-0a138810c4f0" />

