### PR TITLE
feat: 로그인 api 연동(진짜최?종?)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    id("com.google.gms.google-services") version "4.4.4"
 }
 
 android {
@@ -54,6 +55,9 @@ android {
 }
 
 dependencies {
+    implementation(platform("com.google.firebase:firebase-bom:34.7.0"))
+    implementation("com.google.firebase:firebase-analytics")
+    implementation("com.google.firebase:firebase-messaging")
     implementation("io.coil-kt:coil-compose:2.6.0")
 
     implementation(libs.navigation.compose) // navigation

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.apptive.japkor"
         minSdk = 33
         targetSdk = 36
-        versionCode = 2
-        versionName = "1.0.1"
+        versionCode = 3
+        versionName = "1.0.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.apptive.japkor"
         minSdk = 33
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".JapkorApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
 
     <application
         android:name=".JapkorApp"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:name=".JapkorApp"
@@ -14,6 +15,19 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.JapKor">
+
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="@string/fcm_default_channel_id" />
+
+        <service
+            android:name=".push.JapKorFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/apptive/japkor/JapkorApp.kt
+++ b/app/src/main/java/com/apptive/japkor/JapkorApp.kt
@@ -1,0 +1,11 @@
+package com.apptive.japkor
+
+import android.app.Application
+import com.apptive.japkor.data.local.TokenProvider
+
+class JapkorApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        TokenProvider.init(this)
+    }
+}

--- a/app/src/main/java/com/apptive/japkor/LoginCallbackActivity.kt
+++ b/app/src/main/java/com/apptive/japkor/LoginCallbackActivity.kt
@@ -2,6 +2,7 @@ package com.apptive.japkor
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import com.apptive.japkor.data.local.TokenProvider
@@ -9,6 +10,7 @@ import com.apptive.japkor.navigation.Screen
 import java.net.URLDecoder
 
 const val EXTRA_START_DESTINATION = "EXTRA_START_DESTINATION"
+private const val TAG = "LoginCallback"
 
 class LoginCallbackActivity : ComponentActivity() {
 
@@ -19,6 +21,18 @@ class LoginCallbackActivity : ComponentActivity() {
             toast("딥링크 URI가 없습니다.")
             finish()
             return
+        }
+
+        val rawParams = uri.queryParameterNames
+            .associateWith { key -> uri.getQueryParameter(key).orEmpty() }
+        val decodedDataJson = uri.getQueryParameter("data")?.let {
+            URLDecoder.decode(it, "UTF-8")
+        }
+
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "OAuth callback rawUri=$uri")
+            Log.d(TAG, "OAuth callback rawParams=$rawParams")
+            Log.d(TAG, "OAuth callback decodedData=$decodedDataJson")
         }
 
         val success = uri.getQueryParameter("success")?.toBoolean() ?: false
@@ -37,9 +51,7 @@ class LoginCallbackActivity : ComponentActivity() {
         }
 
         val memberId = uri.getQueryParameter("memberId")
-        val dataJson = uri.getQueryParameter("data")?.let {
-            URLDecoder.decode(it, "UTF-8")
-        }
+        val dataJson = decodedDataJson
 
         // ✅ 신규/기존 상관없이 success면 토큰 저장이 최우선
         if (accessToken.isNullOrBlank()) {

--- a/app/src/main/java/com/apptive/japkor/LoginCallbackActivity.kt
+++ b/app/src/main/java/com/apptive/japkor/LoginCallbackActivity.kt
@@ -5,9 +5,14 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import com.apptive.japkor.data.local.DataStoreManager
 import com.apptive.japkor.data.local.TokenProvider
+import com.apptive.japkor.data.model.UserStatus
 import com.apptive.japkor.navigation.Screen
+import kotlinx.coroutines.launch
 import java.net.URLDecoder
+import org.json.JSONObject
 
 const val EXTRA_START_DESTINATION = "EXTRA_START_DESTINATION"
 private const val TAG = "LoginCallback"
@@ -28,6 +33,9 @@ class LoginCallbackActivity : ComponentActivity() {
         val decodedDataJson = uri.getQueryParameter("data")?.let {
             URLDecoder.decode(it, "UTF-8")
         }
+        val dataObject = decodedDataJson?.let { json ->
+            runCatching { JSONObject(json) }.getOrNull()
+        }
 
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "OAuth callback rawUri=$uri")
@@ -42,15 +50,22 @@ class LoginCallbackActivity : ComponentActivity() {
             return
         }
 
-        val needsProfileCompletion =
-            uri.getQueryParameter("needsProfileCompletion")?.toBoolean() ?: false
+        val needsProfileCompletion = uri.getQueryParameter("needsProfileCompletion")?.toBoolean()
+        val statusParam = uri.getQueryParameter("status")?.takeIf { it.isNotBlank() }
+        val statusFromData = dataObject?.optString("status")?.takeIf { it.isNotBlank() }
+        val userStatus = (statusParam ?: statusFromData)?.let { status ->
+            runCatching { UserStatus.valueOf(status) }.getOrNull()
+        }
 
         // 서버가 토큰을 query로 주는 경우 인코딩 이슈 대비 (안전하게 decode)
         val accessToken = uri.getQueryParameter("accessToken")?.let {
             URLDecoder.decode(it, "UTF-8")
-        }
+        } ?: dataObject?.optString("accessToken")?.takeIf { it.isNotBlank() }
 
-        val memberId = uri.getQueryParameter("memberId")
+        val memberIdParam = uri.getQueryParameter("memberId")
+        val memberIdValue = memberIdParam?.toIntOrNull()
+            ?: dataObject?.optInt("memberId", -1)?.takeIf { it > 0 }
+        val nameValue = dataObject?.optString("name")?.takeIf { it.isNotBlank() }.orEmpty()
         val dataJson = decodedDataJson
 
         // ✅ 신규/기존 상관없이 success면 토큰 저장이 최우선
@@ -64,23 +79,43 @@ class LoginCallbackActivity : ComponentActivity() {
         // (선택) 디버깅용: 필요하면 잠깐 켜두기
         // toast("token saved: ${accessToken.take(10)}...")
 
-        val startRoute = if (needsProfileCompletion) {
-            Screen.RequiredInfo.route
-        } else {
-            Screen.RequiredInfoComplete.route
+        val startRoute = when (userStatus) {
+            UserStatus.INCOMPLETE_PROFILE -> Screen.RequiredInfo.route
+            UserStatus.PENDING_APPROVAL,
+            UserStatus.APPROVED,
+            UserStatus.CONNECTING,
+            UserStatus.CONNECTED,
+            UserStatus.BLACKLISTED -> Screen.RequiredInfoComplete.route
+            null -> when (needsProfileCompletion) {
+                true -> Screen.RequiredInfo.route
+                false -> Screen.RequiredInfoComplete.route
+                null -> Screen.RequiredInfo.route
+            }
         }
+
+        val statusValueToSave = userStatus?.name
+            ?: if (needsProfileCompletion == true) UserStatus.INCOMPLETE_PROFILE.name else ""
 
         val i = Intent(this, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
             putExtra(EXTRA_START_DESTINATION, startRoute)
 
             // 필요하면 전달 (안 써도 됨)
-            putExtra("memberId", memberId)
+            putExtra("memberId", memberIdParam)
             putExtra("dataJson", dataJson)
         }
 
-        startActivity(i)
-        finish()
+        val dataStore = DataStoreManager(this)
+        lifecycleScope.launch {
+            dataStore.saveUserInfo(
+                memberId = memberIdValue ?: -1,
+                name = nameValue,
+                token = accessToken,
+                status = statusValueToSave
+            )
+            startActivity(i)
+            finish()
+        }
     }
 
     private fun toast(msg: String) {

--- a/app/src/main/java/com/apptive/japkor/LoginCallbackActivity.kt
+++ b/app/src/main/java/com/apptive/japkor/LoginCallbackActivity.kt
@@ -4,59 +4,71 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
+import com.apptive.japkor.data.local.TokenProvider
 import com.apptive.japkor.navigation.Screen
 import java.net.URLDecoder
 
 const val EXTRA_START_DESTINATION = "EXTRA_START_DESTINATION"
+
 class LoginCallbackActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val uri = intent.data
-        if (uri == null) {
+        val uri = intent.data ?: run {
             toast("딥링크 URI가 없습니다.")
             finish()
             return
         }
 
         val success = uri.getQueryParameter("success")?.toBoolean() ?: false
-        val needsProfileCompletion =
-            uri.getQueryParameter("needsProfileCompletion")?.toBoolean() ?: false
-        val accessToken = uri.getQueryParameter("accessToken") // 신규 회원일 경우 없을 수도 있다
-        val memberId = uri.getQueryParameter("memberId")       // 문자열로 일단 받기
-        val dataJson = uri.getQueryParameter("data")
-            ?.let { URLDecoder.decode(it, "UTF-8") }
-
         if (!success) {
             toast("로그인 실패")
             finish()
             return
         }
 
-        // 신규 회원 → 추가 정보 입력 필요
-        if (needsProfileCompletion) {
-            val i = Intent(this, MainActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                putExtra(EXTRA_START_DESTINATION, Screen.RequiredInfo.route)
-            }
-            startActivity(i)
+        val needsProfileCompletion =
+            uri.getQueryParameter("needsProfileCompletion")?.toBoolean() ?: false
+
+        // 서버가 토큰을 query로 주는 경우 인코딩 이슈 대비 (안전하게 decode)
+        val accessToken = uri.getQueryParameter("accessToken")?.let {
+            URLDecoder.decode(it, "UTF-8")
+        }
+
+        val memberId = uri.getQueryParameter("memberId")
+        val dataJson = uri.getQueryParameter("data")?.let {
+            URLDecoder.decode(it, "UTF-8")
+        }
+
+        // ✅ 신규/기존 상관없이 success면 토큰 저장이 최우선
+        if (accessToken.isNullOrBlank()) {
+            toast("액세스 토큰이 없습니다.")
             finish()
             return
         }
+        TokenProvider.setToken(accessToken)
 
-//        // 기존 회원 → 바로 메인 화면으로
-//        if (accessToken.isNullOrBlank()) {
-//            toast("액세스 토큰이 없습니다.")
-//            finish()
-//            return
-//        }
-//
-//        val i = Intent(this, MainActivity::class.java).apply {
-//            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-//        }
-//        startActivity(i)
-//        finish()
+        // (선택) 디버깅용: 필요하면 잠깐 켜두기
+        // toast("token saved: ${accessToken.take(10)}...")
+
+        val startRoute = if (needsProfileCompletion) {
+            Screen.RequiredInfo.route
+        } else {
+            Screen.RequiredInfoComplete.route
+        }
+
+        val i = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            putExtra(EXTRA_START_DESTINATION, startRoute)
+
+            // 필요하면 전달 (안 써도 됨)
+            putExtra("memberId", memberId)
+            putExtra("dataJson", dataJson)
+        }
+
+        startActivity(i)
+        finish()
     }
 
     private fun toast(msg: String) {

--- a/app/src/main/java/com/apptive/japkor/MainActivity.kt
+++ b/app/src/main/java/com/apptive/japkor/MainActivity.kt
@@ -1,13 +1,19 @@
 package com.apptive.japkor
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -15,6 +21,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.rememberNavController
 import com.apptive.japkor.data.local.DataStoreManager
 import com.apptive.japkor.navigation.AppNavHost
@@ -25,12 +33,37 @@ import com.apptive.japkor.ui.components.ToastManager
 import com.apptive.japkor.ui.components.ToastProvider
 import com.apptive.japkor.ui.localization.AppLanguage
 import com.apptive.japkor.ui.localization.LocalAppLanguage
+import com.apptive.japkor.push.ensureDefaultNotificationChannel
+import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
+    private val notificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            Log.d(TAG, "Notification permission granted=$granted")
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         enableEdgeToEdge()
+
+        ensureDefaultNotificationChannel(this)
+
+        val dataStoreManager = DataStoreManager(this)
+        FirebaseMessaging.getInstance().token
+            .addOnCompleteListener { task ->
+                if (!task.isSuccessful) {
+                    Log.w(TAG, "Fetching FCM registration token failed", task.exception)
+                    return@addOnCompleteListener
+                }
+
+                val token = task.result
+                Log.d(TAG, "FCM token: $token")
+                lifecycleScope.launch {
+                    dataStoreManager.saveFcmToken(token)
+                }
+            }
 
         val startDestinationFromIntent =
             intent.getStringExtra(EXTRA_START_DESTINATION)
@@ -39,14 +72,35 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             JapKorTheme {
-                MainScreen(startDestination = startDestination)
+                MainScreen(
+                    startDestination = startDestination,
+                    onRequestNotificationPermission = ::requestNotificationPermission
+                )
             }
         }
+    }
+
+    private fun requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+
+        val permission = Manifest.permission.POST_NOTIFICATIONS
+        if (ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED) {
+            return
+        }
+
+        notificationPermissionLauncher.launch(permission)
+    }
+
+    companion object {
+        private const val TAG = "MainActivity"
     }
 }
 
 @Composable
-fun MainScreen(startDestination: String) {
+fun MainScreen(
+    startDestination: String,
+    onRequestNotificationPermission: () -> Unit
+) {
     var signedIn by remember { mutableStateOf(false) }
     val navController = rememberNavController()
     val toastManager = remember { ToastManager() }
@@ -54,6 +108,10 @@ fun MainScreen(startDestination: String) {
     val dataStore = remember { DataStoreManager(context) }
     val languageCode by dataStore.getLanguage().collectAsState(initial = AppLanguage.Korean.code)
     val appLanguage = AppLanguage.fromCode(languageCode)
+
+    LaunchedEffect(Unit) {
+        onRequestNotificationPermission()
+    }
 
     ToastProvider(manager = toastManager) {
         CompositionLocalProvider(LocalAppLanguage provides appLanguage) {

--- a/app/src/main/java/com/apptive/japkor/data/local/DataStoreManager.kt
+++ b/app/src/main/java/com/apptive/japkor/data/local/DataStoreManager.kt
@@ -18,6 +18,7 @@ class DataStoreManager(private val context: Context) {
         val KEY_STATUS = stringPreferencesKey("status")
         val KEY_REMEMBERED_EMAIL = stringPreferencesKey("remembered_email")
         val KEY_LANGUAGE = stringPreferencesKey("app_language")
+        val KEY_FCM_TOKEN = stringPreferencesKey("fcm_token")
     }
 
     suspend fun saveUserInfo(memberId: Int, name: String, token: String, status: String) {
@@ -41,6 +42,14 @@ class DataStoreManager(private val context: Context) {
             "status" to (it[KEY_STATUS] ?: "")
         )
     }
+
+    suspend fun saveFcmToken(token: String) {
+        context.dataStore.edit { prefs ->
+            prefs[KEY_FCM_TOKEN] = token
+        }
+    }
+
+    fun getFcmToken() = context.dataStore.data.map { it[KEY_FCM_TOKEN] ?: "" }
 
     suspend fun saveRememberedEmail(email: String) {
         context.dataStore.edit { prefs ->

--- a/app/src/main/java/com/apptive/japkor/data/local/TokenProvider.kt
+++ b/app/src/main/java/com/apptive/japkor/data/local/TokenProvider.kt
@@ -1,12 +1,33 @@
 package com.apptive.japkor.data.local
 
-object TokenProvider {
-    @Volatile
-    private var token: String? = null
+import android.content.Context
 
-    fun setToken(newToken: String) {
-        token = newToken
+object TokenProvider {
+    private const val PREFS_NAME = "auth"
+    private const val KEY_ACCESS_TOKEN = "accessToken"
+
+    private lateinit var appContext: Context
+
+    fun init(context: Context) {
+        appContext = context.applicationContext
     }
 
-    fun getToken(): String? = token
+    fun setToken(newToken: String) {
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_ACCESS_TOKEN, newToken)
+            .apply()
+    }
+
+    fun getToken(): String? {
+        return appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(KEY_ACCESS_TOKEN, null)
+    }
+
+    fun clearToken() {
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .remove(KEY_ACCESS_TOKEN)
+            .apply()
+    }
 }

--- a/app/src/main/java/com/apptive/japkor/data/model/Auth.kt
+++ b/app/src/main/java/com/apptive/japkor/data/model/Auth.kt
@@ -38,5 +38,6 @@ data class SignUpDTO(
 
 data class SignInDTO(
     val email: String,
-    val password: String
+    val password: String,
+    val fcmToken: String,
 )

--- a/app/src/main/java/com/apptive/japkor/data/model/Auth.kt
+++ b/app/src/main/java/com/apptive/japkor/data/model/Auth.kt
@@ -31,7 +31,6 @@ enum class UserStatus(val displayLabel: String) {
 
 // 회원가입 요청 데이터 모델
 data class SignUpDTO(
-    val name: String,
     val email: String,
     val password: String
 )

--- a/app/src/main/java/com/apptive/japkor/data/model/RequiredInfo.kt
+++ b/app/src/main/java/com/apptive/japkor/data/model/RequiredInfo.kt
@@ -2,6 +2,7 @@ package com.apptive.japkor.data.model
 
 // 전체필수정보 DTO
 data class RequiredInfoDTO(
+    val name: String,
     val gender: String,
     val height: Int,
     val weight: Int,

--- a/app/src/main/java/com/apptive/japkor/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/apptive/japkor/data/repository/AuthRepository.kt
@@ -42,8 +42,8 @@ class AuthRepository(
         return response.isSuccessful
     }
 
-    suspend fun signIn(email:String,password:String) : SignInResponse?{
-        val response = api.signIn(SignInDTO(email,password)).awaitResponse()
+    suspend fun signIn(email: String, password: String, fcmToken: String) : SignInResponse?{
+        val response = api.signIn(SignInDTO(email, password, fcmToken)).awaitResponse()
         Log.d("AuthRepository", "signIn success=${response.isSuccessful} code=${response.code()}")
 
         return if (response.isSuccessful) {

--- a/app/src/main/java/com/apptive/japkor/push/JapKorFirebaseMessagingService.kt
+++ b/app/src/main/java/com/apptive/japkor/push/JapKorFirebaseMessagingService.kt
@@ -1,0 +1,65 @@
+package com.apptive.japkor.push
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.apptive.japkor.MainActivity
+import com.apptive.japkor.R
+import com.apptive.japkor.data.local.DataStoreManager
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class JapKorFirebaseMessagingService : FirebaseMessagingService() {
+
+    override fun onNewToken(token: String) {
+        Log.d(TAG, "New FCM token: $token")
+        CoroutineScope(Dispatchers.IO).launch {
+            DataStoreManager(applicationContext).saveFcmToken(token)
+        }
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        val title = message.notification?.title ?: message.data["title"]
+        val body = message.notification?.body ?: message.data["body"]
+
+        if (title.isNullOrBlank() && body.isNullOrBlank()) {
+            Log.d(TAG, "Skipping notification: empty payload")
+            return
+        }
+
+        ensureDefaultNotificationChannel(this)
+
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val channelId = getString(R.string.fcm_default_channel_id)
+        val notification = NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(title ?: getString(R.string.app_name))
+            .setContentText(body.orEmpty())
+            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        NotificationManagerCompat.from(this)
+            .notify(System.currentTimeMillis().toInt(), notification)
+    }
+
+    companion object {
+        private const val TAG = "FcmService"
+    }
+}

--- a/app/src/main/java/com/apptive/japkor/push/NotificationChannels.kt
+++ b/app/src/main/java/com/apptive/japkor/push/NotificationChannels.kt
@@ -1,0 +1,24 @@
+package com.apptive.japkor.push
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import com.apptive.japkor.R
+
+fun ensureDefaultNotificationChannel(context: Context) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+    val channelId = context.getString(R.string.fcm_default_channel_id)
+    val manager = context.getSystemService(NotificationManager::class.java) ?: return
+    if (manager.getNotificationChannel(channelId) != null) return
+
+    val channelName = context.getString(R.string.fcm_default_channel_name)
+    val channelDescription = context.getString(R.string.fcm_default_channel_description)
+    val importance = NotificationManager.IMPORTANCE_HIGH
+
+    val channel = NotificationChannel(channelId, channelName, importance).apply {
+        description = channelDescription
+    }
+    manager.createNotificationChannel(channel)
+}

--- a/app/src/main/java/com/apptive/japkor/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/apptive/japkor/ui/login/LoginScreen.kt
@@ -332,22 +332,22 @@ fun LoginScreen(navController: NavController,viewModel: LoginScreenViewModel = v
 //                )
 //            }
 
-//            Row(
-//                modifier = Modifier
-//                    .fillMaxWidth()
-//                    .padding(top = 16.dp, bottom = 90.dp),
-//                horizontalArrangement = Arrangement.Center,
-//
-//                ) {
-//                GoogleSignUpButton(
-//                    onClick = {
-//                        val url = "https://masil-main.duckdns.org/oauth2/authorization/google"
-//                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-//                        context.startActivity(intent)
-//                    }
-//                )
-//
-//            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp, bottom = 90.dp),
+                horizontalArrangement = Arrangement.Center,
+
+                ) {
+                GoogleSignUpButton(
+                    onClick = {
+                        val url = "https://masil-main.duckdns.org/oauth2/authorization/google"
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                        context.startActivity(intent)
+                    }
+                )
+
+            }
 
 
 //            Row(

--- a/app/src/main/java/com/apptive/japkor/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/apptive/japkor/ui/login/LoginScreen.kt
@@ -282,7 +282,15 @@ fun LoginScreen(navController: NavController,viewModel: LoginScreenViewModel = v
                                 navController.navigate(Screen.SignUp.route)
                             }
                         )
+
                     }
+                    GoogleSignUpButton(
+                        onClick = {
+                            val url = "https://masil-main.duckdns.org/oauth2/authorization/google"
+                            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                            context.startActivity(intent)
+                        }
+                    )
                 }
             }
 
@@ -291,19 +299,19 @@ fun LoginScreen(navController: NavController,viewModel: LoginScreenViewModel = v
         }
 
         // 하단 고정 버튼 영역
-        Column(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth()
-                .background(Color.White)
-                .padding(horizontal = 24.dp)
-                .padding(
-                    bottom = WindowInsets.navigationBars.asPaddingValues()
-                        .calculateBottomPadding() + 16.dp
-                ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
+//        Column(
+//            modifier = Modifier
+//                .align(Alignment.BottomCenter)
+//                .fillMaxWidth()
+//                .background(Color.White)
+//                .padding(horizontal = 24.dp)
+//                .padding(
+//                    bottom = WindowInsets.navigationBars.asPaddingValues()
+//                        .calculateBottomPadding() + 16.dp
+//                ),
+//            horizontalAlignment = Alignment.CenterHorizontally,
+//            verticalArrangement = Arrangement.spacedBy(16.dp)
+//        ) {
 //            Row(
 //                modifier = Modifier.fillMaxWidth(),
 //                horizontalArrangement = Arrangement.Center
@@ -332,22 +340,7 @@ fun LoginScreen(navController: NavController,viewModel: LoginScreenViewModel = v
 //                )
 //            }
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 16.dp, bottom = 90.dp),
-                horizontalArrangement = Arrangement.Center,
 
-                ) {
-                GoogleSignUpButton(
-                    onClick = {
-                        val url = "https://masil-main.duckdns.org/oauth2/authorization/google"
-                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-                        context.startActivity(intent)
-                    }
-                )
-
-            }
 
 
 //            Row(
@@ -377,4 +370,3 @@ fun LoginScreen(navController: NavController,viewModel: LoginScreenViewModel = v
 
         }
     }
-}

--- a/app/src/main/java/com/apptive/japkor/ui/login/LoginScreenViewModel.kt
+++ b/app/src/main/java/com/apptive/japkor/ui/login/LoginScreenViewModel.kt
@@ -8,10 +8,14 @@ import com.apptive.japkor.data.local.DataStoreManager
 import com.apptive.japkor.data.local.TokenProvider
 import com.apptive.japkor.data.model.UserStatus
 import com.apptive.japkor.data.repository.AuthRepository
+import com.google.firebase.messaging.FirebaseMessaging
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 class LoginScreenViewModel(
     application: Application,
@@ -42,7 +46,12 @@ class LoginScreenViewModel(
             Log.d("LoginVM", "signIn 호출: email=$email, password=$password")
 
             try {
-                val fcmToken = dataStore.getFcmToken().first()
+                val fcmToken = getOrFetchFcmToken()
+                if (fcmToken.isBlank()) {
+                    Log.e("LoginVM", "FCM token missing; aborting signIn")
+                    onResult(false, null)
+                    return@launch
+                }
                 val result = repository.signIn(email, password, fcmToken)
                 if (result != null) {
                     Log.d("LoginVM", "로그인 성공! token=${result.token}")
@@ -69,6 +78,36 @@ class LoginScreenViewModel(
                 _isLoading.value = false
             }
         }
+    }
+
+    private suspend fun getOrFetchFcmToken(): String {
+        val cachedToken = dataStore.getFcmToken().first()
+        if (cachedToken.isNotBlank()) return cachedToken
+
+        return try {
+            val token = fetchFcmToken()
+            if (token.isNotBlank()) {
+                dataStore.saveFcmToken(token)
+            }
+            token
+        } catch (e: Exception) {
+            Log.w("LoginVM", "FCM token fetch failed", e)
+            ""
+        }
+    }
+
+    private suspend fun fetchFcmToken(): String = suspendCancellableCoroutine { cont ->
+        FirebaseMessaging.getInstance().token
+            .addOnCompleteListener { task ->
+                if (!cont.isActive) return@addOnCompleteListener
+                if (task.isSuccessful) {
+                    cont.resume(task.result.orEmpty())
+                } else {
+                    cont.resumeWithException(
+                        task.exception ?: IllegalStateException("FCM token fetch failed")
+                    )
+                }
+            }
     }
 
     fun updateRememberedEmail(remember: Boolean, email: String) {

--- a/app/src/main/java/com/apptive/japkor/ui/login/LoginScreenViewModel.kt
+++ b/app/src/main/java/com/apptive/japkor/ui/login/LoginScreenViewModel.kt
@@ -42,7 +42,8 @@ class LoginScreenViewModel(
             Log.d("LoginVM", "signIn 호출: email=$email, password=$password")
 
             try {
-                val result = repository.signIn(email, password)
+                val fcmToken = dataStore.getFcmToken().first()
+                val result = repository.signIn(email, password, fcmToken)
                 if (result != null) {
                     Log.d("LoginVM", "로그인 성공! token=${result.token}")
                     TokenProvider.setToken(result.token)

--- a/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoViewModel.kt
+++ b/app/src/main/java/com/apptive/japkor/ui/requiredinfo/RequiredInfoViewModel.kt
@@ -53,6 +53,10 @@ class RequiredInfoViewModel(
     val gender: StateFlow<String?> = _gender
     fun setGender(label: String) { _gender.value = RequiredInfoMapper.gender(label) }
 
+    private val _name = MutableStateFlow("")
+    val name: StateFlow<String> = _name
+    fun setName(value: String) { _name.value = value }
+
     private val _height = MutableStateFlow<Int?>(null)
     val height: StateFlow<Int?> = _height
     fun setHeight(value: Int?) { _height.value = value }
@@ -209,15 +213,16 @@ class RequiredInfoViewModel(
 
     @Suppress("UNCHECKED_CAST")
     val step2Valid: StateFlow<Boolean> = combine(
-        height, weight, region, smoking, drinking, religion
+        name, height, weight, region, smoking, drinking, religion
     ) { values ->
-        val h = values[0] as Int?
-        val w = values[1] as Int?
-        val r = values[2] as String
-        val s = values[3] as String?
-        val d = values[4] as String?
-        val rel = values[5] as String?
-        h != null && w != null && r.isNotBlank() && s != null && d != null && rel != null
+        val n = values[0] as String
+        val h = values[1] as Int?
+        val w = values[2] as Int?
+        val r = values[3] as String
+        val s = values[4] as String?
+        val d = values[5] as String?
+        val rel = values[6] as String?
+        n.isNotBlank() && h != null && w != null && r.isNotBlank() && s != null && d != null && rel != null
     }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     val step3Valid: StateFlow<Boolean> = combine(
@@ -304,6 +309,8 @@ class RequiredInfoViewModel(
         val profileImageUrls = uploadedImages.mapNotNull { it.uploadedUrl }
         val thumbnailImageUrl = profileImageUrls.firstOrNull()
 
+        val name = _name.value.trim()
+        if (name.isEmpty()) return setError("이름을 입력해주세요.")
         val gender = _gender.value ?: return setError("성별을 선택해주세요.")
         val height = _height.value ?: return setError("키를 입력해주세요.")
         val weight = _weight.value ?: return setError("몸무게를 입력해주세요.")
@@ -370,6 +377,7 @@ class RequiredInfoViewModel(
         if (priorities.toSet().size != 3) return setError("우선순위는 중복될 수 없습니다.")
 
         val dto = RequiredInfoDTO(
+            name = name,
             gender = gender,
             height = height,
             weight = weight,

--- a/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step2Content.kt
+++ b/app/src/main/java/com/apptive/japkor/ui/requiredinfo/steps/Step2Content.kt
@@ -20,6 +20,7 @@ import com.apptive.japkor.utils.required_info.RequiredInfoMapper
 fun Step2Content(
     viewModel: RequiredInfoViewModel
 ) {
+    val name by viewModel.name.collectAsState()
     val height by viewModel.height.collectAsState()
     val weight by viewModel.weight.collectAsState()
     val region by viewModel.region.collectAsState()
@@ -53,7 +54,7 @@ fun Step2Content(
         Spacer(modifier = Modifier.height(5.dp))
 
         // ============================
-        //  키 / 몸무게 / 거주 지역 입력
+        //  이름 / 키 / 몸무게 / 거주 지역 입력
         // ============================
         Column(
             modifier = Modifier
@@ -62,6 +63,13 @@ fun Step2Content(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
+
+            // 이름 입력 (String)
+            CustomOutlinedTextField(
+                value = name,
+                onValueChange = { viewModel.setName(it) },
+                placeholder = "이름(실명)"
+            )
 
             // 키 입력 (Int?)
             CustomOutlinedTextField(

--- a/app/src/main/java/com/apptive/japkor/ui/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/apptive/japkor/ui/signup/SignUpScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.apptive.japkor.R
-import com.apptive.japkor.ui.components.CustomOutlinedTextField
 import com.apptive.japkor.ui.components.CustomText
 import com.apptive.japkor.ui.components.CustomTextType
 import com.apptive.japkor.ui.theme.CustomColor
@@ -69,8 +68,6 @@ import com.apptive.japkor.ui.localization.LocalAppLanguage
 fun SignUpScreen(navController: NavController, viewModel: SignUpViewModel = viewModel()) {
     val toastManager = LocalToastManager.current
     val appLanguage = LocalAppLanguage.current
-
-    var name by remember { mutableStateOf("") }
 
     var emailLocal by remember { mutableStateOf("") }   // @ 앞
     var emailDomain by remember { mutableStateOf("") }  // @ 뒤
@@ -194,20 +191,7 @@ fun SignUpScreen(navController: NavController, viewModel: SignUpViewModel = view
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            CustomText(
-                text = "이름",
-                type = CustomTextType.body,
-                color = CustomColor.black,
-                size = 15.sp
-            )
-            CustomOutlinedTextField(
-                value = name,
-                onValueChange = { name = it },
-                placeholder = "이름"
-            )
-
             // 이메일
-            Spacer(modifier = Modifier.height(16.dp))
             EmailWithAuthSection(
                 emailLocal = emailLocal,
                 onEmailLocalChange = { emailLocal = it },
@@ -251,13 +235,11 @@ fun SignUpScreen(navController: NavController, viewModel: SignUpViewModel = view
                 onClick = {
                     val email = "$emailLocal@$emailDomain"
                     viewModel.signUp(
-                        name = name,
                         email = email,
                         password = password
                     )
                 },
-                enabled = name.isNotBlank()
-                        && emailLocal.isNotBlank()
+                enabled = emailLocal.isNotBlank()
                         && emailDomain.isNotBlank()
                         && authCode.isNotBlank()
                         && password.isNotBlank()

--- a/app/src/main/java/com/apptive/japkor/ui/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/apptive/japkor/ui/signup/SignUpViewModel.kt
@@ -100,14 +100,12 @@ class SignUpViewModel(
     }
 
     fun signUp(
-        name: String,
         email: String,
         password: String
     ) {
         viewModelScope.launch {
             _isLoading.value = true
             val request = SignUpDTO(
-                name = name,
                 email = email,
                 password = password
             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">en</string>
+    <string name="app_name">n</string>
     <string name="default_web_client_id">504737014677-p232m5s4jtl1t1v48ff6ir7gl3pcjokp.apps.googleusercontent.com</string>
     <string name="fcm_default_channel_id">fcm_default_channel</string>
     <string name="fcm_default_channel_name">Default notifications</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,7 @@
 <resources>
     <string name="app_name">en</string>
     <string name="default_web_client_id">504737014677-p232m5s4jtl1t1v48ff6ir7gl3pcjokp.apps.googleusercontent.com</string>
+    <string name="fcm_default_channel_id">fcm_default_channel</string>
+    <string name="fcm_default_channel_name">Default notifications</string>
+    <string name="fcm_default_channel_description">General notifications</string>
 </resources>


### PR DESCRIPTION
## 🚀 PR 개요

OAuth 딥링크 콜백에서 accessToken 저장 및 신규/기존 분기 처리 적용

- accessToken을 SharedPreferences 기반 TokenProvider에 저장하도록 변경 (토큰 영구 저장으로 바꿈: 왜냐면 구글 로그인하고 다시 앱으로 돌아올 때 토큰이 사라질까봐) (기존에는 메모리 기반)
- JapkorApp(Application)에서 TokenProvider 초기화
- 신규 회원(needsProfileCompletion=true) → RequiredInfo로, 기존 회원 → Home으로 분기

## 🔗 관련 이슈

- #53 

## 🧩 작업 상세

- [x] `TokenProvider`: 메모리 -> SharedPreferences 기반으로 변경, init 추가
- [x] `JapKorApp`: 앱 시작 시 TokenProvider.init 호출
- [x] `AndroidManifest`: application name 설정
- [x] `LoginCallbackActivity`: success 이후 토큰 저장을 분기 이전에 수행 + startDestination 전달

## ⚠️ 미완성 작업

- [x] 아직 검토를 제대로 안 함

## 📎 참고 사항

뭔가문제많을것같아서불안함
