### PR TITLE
feat - 내정보페이지 구현

### DIFF
--- a/app/src/main/java/com/apptive/japkor/data/local/DataStoreManager.kt
+++ b/app/src/main/java/com/apptive/japkor/data/local/DataStoreManager.kt
@@ -10,6 +10,9 @@ import androidx.datastore.preferences.preferencesDataStore
 import com.apptive.japkor.data.model.UserInfoResponse
 import com.google.gson.Gson
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import com.apptive.japkor.utils.required_info.RequiredInfoReverseMapper
 
 private val Context.dataStore by preferencesDataStore(name = "user_prefs")
 
@@ -223,6 +226,49 @@ class DataStoreManager(private val context: Context) {
             prefs.remove(key)
         } else {
             prefs[key] = value
+        }
+    }
+
+    // My Profile UI Model and Flow
+    data class MyProfileUiModel(
+        val name: String,
+        val residenceArea: String,
+        val smokingStatus: String,
+        val drinkingFrequency: String,
+        val education: String,
+        val religion: String,
+        val thumbnailImageUrl: String,
+    )
+
+    fun getMyProfileUiModel(): Flow<MyProfileUiModel> {
+        val nameFlow = getUserName()
+        val residenceFlow = context.dataStore.data.map { it[KEY_RESIDENCE_AREA] ?: "" }
+        val smokingFlow = context.dataStore.data.map { it[KEY_SMOKING_STATUS] ?: "" }
+        val drinkingFlow = context.dataStore.data.map { it[KEY_DRINKING_FREQUENCY] ?: "" }
+        val educationFlow = context.dataStore.data.map { it[KEY_EDUCATION] ?: "" }
+        val religionFlow = context.dataStore.data.map { it[KEY_RELIGION] ?: "" }
+        val thumbFlow = context.dataStore.data.map { it[KEY_THUMBNAIL_IMAGE_URL] ?: "" }
+
+        return combine(
+            nameFlow, residenceFlow, smokingFlow, drinkingFlow, educationFlow, religionFlow, thumbFlow
+        ) { values: Array<String> ->
+            val name = values[0]
+            val residence = values[1]
+            val smokingCode = values[2]
+            val drinkingCode = values[3]
+            val educationCode = values[4]
+            val religionCode = values[5]
+            val thumb = values[6]
+
+            MyProfileUiModel(
+                name = name,
+                residenceArea = residence,
+                smokingStatus = RequiredInfoReverseMapper.smoking(smokingCode),
+                drinkingFrequency = RequiredInfoReverseMapper.drinking(drinkingCode),
+                education = RequiredInfoReverseMapper.education(educationCode),
+                religion = RequiredInfoReverseMapper.religion(religionCode),
+                thumbnailImageUrl = thumb
+            )
         }
     }
 }

--- a/app/src/main/java/com/apptive/japkor/ui/components/CommonHeader.kt
+++ b/app/src/main/java/com/apptive/japkor/ui/components/CommonHeader.kt
@@ -1,0 +1,58 @@
+package com.apptive.japkor.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.apptive.japkor.ui.theme.CustomColor
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.apptive.japkor.R
+
+@Composable
+fun CommonHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+    showBackButton: Boolean = true,
+    onBack: (() -> Unit)? = null,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium
+            )
+
+            // 왼쪽 영역: 버튼이 없어도 자리(48dp) 유지해서 제목이 안 흔들림
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .size(48.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                if (showBackButton && onBack != null) {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_back),
+                            contentDescription = "back",
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
+                }
+            }
+        }
+
+        HorizontalDivider(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            color = CustomColor.gray300,
+            thickness = 1.dp
+        )
+
+    }
+}

--- a/app/src/main/java/com/apptive/japkor/ui/main/mypage/MypageScreen.kt
+++ b/app/src/main/java/com/apptive/japkor/ui/main/mypage/MypageScreen.kt
@@ -1,24 +1,264 @@
 package com.apptive.japkor.ui.main.mypage
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.apptive.japkor.data.local.DataStoreManager
+import com.apptive.japkor.data.local.DataStoreManager.MyProfileUiModel
+import com.apptive.japkor.ui.components.CommonHeader
 import com.apptive.japkor.ui.components.CustomText
 import com.apptive.japkor.ui.components.CustomTextType
 import com.apptive.japkor.ui.theme.CustomColor
 
 @Composable
-fun MypageScreen(modifier: Modifier = Modifier) {
-    Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+fun MypageScreen(
+    modifier: Modifier = Modifier,
+    showBackButton: Boolean = true,
+    onBack: (() -> Unit)? = null,
+) {
+    val context = LocalContext.current
+    val dataStoreManager = DataStoreManager(context)
+
+    val profile by dataStoreManager.getMyProfileUiModel()
+        .collectAsState(initial = null)
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        CommonHeader(
+            title = "마이페이지",
+            showBackButton = showBackButton,
+            onBack = onBack
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp)
+        ) {
+            Spacer(Modifier.height(16.dp))
+
+            MyProfileCard(profile = profile)
+
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun MyProfileCard(profile: MyProfileUiModel?) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .dashedBorder(
+                color = Color(0xFFD7D7D7),
+                strokeWidth = 1.dp,
+                cornerRadius = 14.dp
+            )
+            .padding(16.dp)
+    ) {
+        // My Profile pill
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            Surface(
+                shape = RoundedCornerShape(999.dp),
+                color = Color.White,
+                shadowElevation = 0.dp,
+                tonalElevation = 0.dp
+            ) {
+                Box(
+                    modifier = Modifier
+                        .background(Color.White, RoundedCornerShape(999.dp))
+                        .drawBehind { }
+                        .padding(horizontal = 14.dp, vertical = 6.dp)
+                ) {
+                    CustomText(
+                        text = "My Profile",
+                        type = CustomTextType.body,
+                        color = CustomColor.gray400
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            //ProfileImageWithBadge(imageUrl = profile?.thumbnailImageUrl) // 돋보기 있는 버전
+            ProfileImage(imageUrl = profile?.thumbnailImageUrl)
+
+            Spacer(Modifier.width(12.dp))
+
+            Column {
+                CustomText(
+                    text = profile?.name?.ifBlank { "—" } ?: "—",
+                    type = CustomTextType.headline,
+                    color = CustomColor.black
+                )
+            }
+        }
+
+        Spacer(Modifier.height(14.dp))
+        HorizontalDivider(color = CustomColor.gray100)
+        Spacer(Modifier.height(10.dp))
+
+        InfoRow(label = "지역", value = profile?.residenceArea ?: "—")
+        InfoRow(label = "흡연", value = profile?.smokingStatus ?: "—")
+        InfoRow(label = "음주", value = profile?.drinkingFrequency ?: "—")
+        InfoRow(label = "학력", value = profile?.education ?: "—")
+        InfoRow(
+            label = "종교",
+            value = profile?.religion ?: "—"
+        )
+
+        Spacer(Modifier.height(12.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = 13.dp,
+                    vertical = 12.dp
+                )
+        ) {
+            CustomText(
+                text = "이미 심사 통과한 프로필은 수정이 어려워요.",
+                type = CustomTextType.body,
+                color = CustomColor.gray300
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProfileImage(imageUrl: String?) {
+    val painter = rememberAsyncImagePainter(model = imageUrl)
+
+    Image(
+        painter = painter,
+        contentDescription = "profile",
+        contentScale = ContentScale.Crop,
+        modifier = Modifier
+            .size(64.dp)
+            .clip(CircleShape)                 // ✅ 원형
+            .background(Color(0xFFEDEDED))     // 로딩/빈값 배경
+    )
+}
+
+//@Composable
+//private fun ProfileImageWithBadge(imageUrl: String?) {
+//    Box(modifier = Modifier.size(70.dp)) {
+//        val painter = rememberAsyncImagePainter(model = imageUrl)
+//
+//        Image(
+//            painter = painter,
+//            contentDescription = "profile",
+//            contentScale = ContentScale.Crop,
+//            modifier = Modifier
+//                .size(64.dp)
+//                .background(Color(0xFFEDEDED), CircleShape)
+//        )
+//
+//        Box(
+//            modifier = Modifier
+//                .size(24.dp)
+//                .align(Alignment.BottomEnd)
+//                .background(Color(0xFF7C8055), CircleShape),
+//            contentAlignment = Alignment.Center
+//        ) {
+//            Icon(
+//                imageVector = Icons.Default.Search,
+//                contentDescription = "search",
+//                tint = Color.White,
+//                modifier = Modifier.size(16.dp)
+//            )
+//        }
+//    }
+//}
+
+@Composable
+private fun InfoRow(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = 13.dp,
+                vertical = 17.dp
+            ),
+        verticalAlignment = Alignment.CenterVertically
     ) {
         CustomText(
-            text = "내정보 페이지입니다.",
+            text = label,
             type = CustomTextType.body,
-            color = CustomColor.gray400
+            color = CustomColor.gray300,
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        CustomText(
+            text = value,
+            type = CustomTextType.title,
+            color = CustomColor.black
         )
     }
+    HorizontalDivider(
+        modifier = Modifier
+            .padding(
+                horizontal = 13.dp,
+                vertical = 0.dp
+            ),
+        color = CustomColor.gray100,
+        thickness = 1.dp
+    )
+}
+
+/**
+ * ✅ 점선 테두리: "여기서만 쓸 거라" 파일 내부에 private로 둠
+ */
+private fun Modifier.dashedBorder(
+    color: Color,
+    strokeWidth: Dp,
+    cornerRadius: Dp,
+    on: Dp = 6.dp,
+    off: Dp = 6.dp,
+) = this.drawBehind {
+    val stroke = Stroke(
+        width = strokeWidth.toPx(),
+        pathEffect = PathEffect.dashPathEffect(
+            floatArrayOf(on.toPx(), off.toPx()),
+            0f
+        )
+    )
+    drawRoundRect(
+        color = color,
+        style = stroke,
+        cornerRadius = CornerRadius(cornerRadius.toPx())
+    )
 }

--- a/app/src/main/java/com/apptive/japkor/ui/theme/CustomColor.kt
+++ b/app/src/main/java/com/apptive/japkor/ui/theme/CustomColor.kt
@@ -17,7 +17,7 @@ object CustomColor {
     val gray400 = Color(0xFF6B7280)
 
     val white = Color(0xFFFFFFFF)
-    val black = Color(0xFF000000)
+    val black = Color(0xFF3C3C3C)
 
 }
 

--- a/app/src/main/java/com/apptive/japkor/utils/required_info/RequiredInfoReverseMapper.kt
+++ b/app/src/main/java/com/apptive/japkor/utils/required_info/RequiredInfoReverseMapper.kt
@@ -1,0 +1,105 @@
+package com.apptive.japkor.utils.required_info
+
+object RequiredInfoReverseMapper {
+
+    // -------------------------------
+    // 흡연 여부
+    // -------------------------------
+    private val smokingMap = mapOf(
+        "SMOKER" to "흡연",
+        "NON_SMOKER" to "비흡연"
+    )
+
+    fun smoking(code: String?): String =
+        smokingMap[code] ?: "-"
+
+    // -------------------------------
+    // 음주 빈도
+    // -------------------------------
+    private val drinkingMap = mapOf(
+        "LESS_THAN_ONCE_A_WEEK" to "주 1회 미만",
+        "ONCE_A_WEEK" to "주 1회",
+        "TWICE_A_WEEK" to "주 2회",
+        "MORE_THAN_THREE_TIMES_A_WEEK" to "주 3회 이상"
+    )
+
+    fun drinking(code: String?): String =
+        drinkingMap[code] ?: "-"
+
+    // -------------------------------
+    // 종교
+    // -------------------------------
+    private val religionMap = mapOf(
+        "NONE" to "무교",
+        "BUDDHISM" to "불교",
+        "CHRISTIANITY" to "기독교",
+        "CATHOLICISM" to "천주교",
+        "TOISM" to "신토",
+        "OTHER" to "기타"
+    )
+
+    fun religion(code: String?): String =
+        religionMap[code] ?: "-"
+
+    // -------------------------------
+    // 학력
+    // -------------------------------
+    private val educationMap = mapOf(
+        "HIGH_SCHOOL" to "고졸",
+        "ASSOCIATE_DEGREE" to "전문학사",
+        "BACHELOR_DEGREE" to "학사",
+        "MASTER_DEGREE" to "석사",
+        "DOCTORATE_DEGREE" to "박사"
+    )
+
+    fun education(code: String?): String =
+        educationMap[code] ?: "-"
+
+    // -------------------------------
+    // 자산
+    // -------------------------------
+    private val assetMap = mapOf(
+        "UNDER_100M" to "1억 미만",
+        "BETWEEN_100M_300M" to "1억 ~ 3억",
+        "BETWEEN_300M_500M" to "3억 ~ 5억",
+        "BETWEEN_500M_1B" to "5억 ~ 10억",
+        "OVER_1B" to "10억 이상"
+    )
+
+    fun asset(code: String?): String =
+        assetMap[code] ?: "-"
+
+    // -------------------------------
+    // 직업
+    // -------------------------------
+    private val jobMap = mapOf(
+        "DOCTOR" to "의사",
+        "PHARMACIST" to "약사",
+        "NURSE" to "간호사",
+        "TEACHER" to "교사",
+        "PROFESSOR" to "교수",
+        "LAWYER" to "변호사",
+        "ACCOUNTANT" to "회계사",
+        "ENGINEER" to "엔지니어",
+        "DEVELOPER" to "개발자",
+        "DESIGNER" to "디자이너",
+        "CIVIL_SERVANT" to "공무원",
+        "POLICE" to "경찰",
+        "FIREFIGHTER" to "소방관",
+        "MILITARY" to "군인",
+        "ENTREPRENEUR" to "사업가",
+        "CEO" to "경영인",
+        "FINANCE" to "금융",
+        "RESEARCHER" to "연구원",
+        "ARTIST" to "예술가",
+        "ATHLETE" to "운동선수",
+        "FREELANCER" to "프리랜서",
+        "STUDENT" to "학생",
+        "UNEMPLOYED" to "무직",
+        "ANY" to "상관없음",
+        "OTHER" to "기타"
+    )
+
+    fun job(code: String?): String =
+        jobMap[code] ?: "-"
+}


### PR DESCRIPTION
## 🚀 PR 개요

DataStoreManager에서 정보 가져와서 내정보페이지 구현했습니다.

## 🔗 관련 이슈

- #83 

## 🧩 작업 상세

- [x] 헤더 공용 컴포넌트 제작 (ui/components/CommonHeader.kt)
- [x] 마이페이지 구현

## 📸 변경 사항 스크린샷 (선택)
<img width="30%" height="100%" alt="image" src="https://github.com/user-attachments/assets/d6b0fd59-1243-4c00-9d83-a712c5491e2a" />

## 📎 참고 사항

설정 아이콘 제거해주세용~~
